### PR TITLE
docs: Fix broken references and remove non-existent flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ go build -o pass-cli .
 go test ./...
 ```
 
-For testing guidelines, see [test/README.md](test/README.md). For Git workflow, see [docs/05-development/branch-workflow.md](docs/05-development/branch-workflow.md).
+For testing guidelines, see [test/README.md](test/README.md). For Git workflow, see [docs/06-development/branch-workflow.md](docs/06-development/branch-workflow.md).
 
 ## FAQ
 
@@ -248,7 +248,7 @@ For more questions and troubleshooting, see [docs/04-troubleshooting/faq.md](doc
 
 ## Contributing
 
-Contributions are welcome! See [docs/05-development/branch-workflow.md](docs/05-development/branch-workflow.md) for Git workflow and contribution guidelines.
+Contributions are welcome! See [docs/06-development/branch-workflow.md](docs/06-development/branch-workflow.md) for Git workflow and contribution guidelines.
 
 ## License
 

--- a/docs/01-getting-started/quick-start.md
+++ b/docs/01-getting-started/quick-start.md
@@ -68,7 +68,7 @@ Store your master password in OS keychain for convenience?
 Benefits:
   ✓ No need to type password for every operation
   ✓ Secure OS-level storage
-  ✓ Can be disabled later with --no-keychain
+  ✓ Can be disabled later via OS credential manager
 
 Enable keychain storage? (y/n): y
 
@@ -159,19 +159,24 @@ pass-cli get github
 
 #### Skip Keychain Integration
 
-```bash
-pass-cli init --no-keychain
-```
-
-Creates a vault without storing the master password in OS keychain. You'll need to enter your password for each operation.
-
-#### Disable Audit Logging
+During the interactive initialization, answer "n" when prompted about keychain storage:
 
 ```bash
-pass-cli init --no-audit
+pass-cli init
+# When asked "Enable keychain storage? (y/n):", enter "n"
 ```
 
-Creates a vault without audit logging enabled (not recommended for production use).
+This creates a vault without storing the master password in OS keychain. You'll need to enter your password for each operation.
+
+#### Enable Audit Logging
+
+Audit logging is disabled by default. To enable it during initialization:
+
+```bash
+pass-cli init --enable-audit
+```
+
+This creates a vault with tamper-evident HMAC-signed audit logging enabled (recommended for production use).
 
 ## Your First Credential
 

--- a/docs/03-reference/command-reference.md
+++ b/docs/03-reference/command-reference.md
@@ -1561,11 +1561,17 @@ secret-tool search service pass-cli
 secret-tool clear service pass-cli vault /old/path/vault.enc
 ```
 
-**Prevention**: When deleting or moving vaults, remove the keychain entry first:
+**Prevention**: When deleting or moving vaults, remove the keychain entry first using your OS credential manager:
+
 ```bash
-# Before deleting vault
-pass-cli change-password --no-keychain  # Disables keychain
-# OR manually remove from OS keychain
+# Windows
+cmdkey /delete:pass-cli
+
+# macOS
+security delete-generic-password -s "pass-cli" -a "$USER"
+
+# Linux
+secret-tool clear service pass-cli vault /old/path/vault.enc
 ```
 
 #### What if first-run detection doesn't trigger?


### PR DESCRIPTION
Clean up documentation by fixing broken links and removing references to flags that were never implemented.

## Fixed Broken References
- **README.md**: `docs/05-development` → `docs/06-development` (2 occurrences)
  - Git workflow and contribution guidelines links now point to correct location

## Removed Non-Existent Flags

### `--no-keychain` (never implemented)
**Before:**
```bash
pass-cli init --no-keychain  # Disables keychain
```

**After:**
- Updated to use interactive prompts during `pass-cli init`
- Replaced with actual OS credential manager commands for removal:
  - Windows: `cmdkey /delete:pass-cli`
  - macOS: `security delete-generic-password -s "pass-cli" -a "$USER"`
  - Linux: `secret-tool clear service pass-cli vault /path`

### `--no-audit` (never implemented)
**Before:**
```bash
pass-cli init --no-audit  # Disable audit logging
```

**After:**
```bash
pass-cli init --enable-audit  # Enable audit logging (disabled by default)
```

## Files Changed
- `README.md` - Fixed 2 broken path references
- `docs/01-getting-started/quick-start.md` - Removed --no-keychain and --no-audit, corrected to interactive prompts and --enable-audit
- `docs/03-reference/command-reference.md` - Replaced --no-keychain with OS-specific commands

## Verification
```bash
./pass-cli init --help
# Shows actual flags:
#   --use-keychain (enable keychain)
#   --enable-audit (enable audit)
#   --no-recovery (skip recovery phrase)
# No --no-keychain or --no-audit flags exist
```