### PR TITLE
chore: tag docsite footer under Reyamira and pin Hugo for Hextra compat

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.155.0'
           extended: true
 
       - name: Install Hugo Book theme

--- a/docsite/i18n/en.yaml
+++ b/docsite/i18n/en.yaml
@@ -1,0 +1,1 @@
+copyright: "© 2026 [Reyamira](https://reyamira.com). Apache 2.0 licensed."


### PR DESCRIPTION
## Summary

- Override Hextra's i18n copyright string so the docsite footer reads `© 2026 Reyamira. Apache 2.0 licensed.` instead of the theme default.
- Pin pages.yml to `hugo-version: 0.155.0`. Hugo 0.156 removed `.Site.Author`, which the bundled Hextra 0.11.1 RSS template still references — leaving `hugo-version: 'latest'` would break the next Pages deploy. The pin holds until a Hextra upgrade resolves the incompatibility.

## Test plan

- [ ] Pages workflow runs on push without RSS template errors
- [ ] Docsite footer renders `© 2026 Reyamira. Apache 2.0 licensed.` with `Reyamira` linking to https://reyamira.com
- [ ] No regression in build time or content rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)