### PR TITLE
feat(list): safe-by-default listing — hide usernames, add -q and --show-usernames (#95)

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -16,12 +16,14 @@ import (
 )
 
 var (
-	listFormat    string
-	listUnused    bool
-	listDays      int
-	listByProject bool   // T029: --by-project flag
-	listLocation  string // T042: --location flag (for User Story 3)
-	listRecursive bool   // T043: --recursive flag (for User Story 3)
+	listFormat        string
+	listUnused        bool
+	listDays          int
+	listByProject     bool   // T029: --by-project flag
+	listLocation      string // T042: --location flag (for User Story 3)
+	listRecursive     bool   // T043: --recursive flag (for User Story 3)
+	listShowUsernames bool   // #95: opt the Username column back into the default table
+	listQuiet         bool   // #95: -q/--quiet alias for --format simple
 )
 
 var listCmd = &cobra.Command{
@@ -35,6 +37,15 @@ Output formats:
   json     Output as JSON array
   simple   Simple list of service names only
 
+Safety: the table hides usernames by default. The "username" field can hold
+sensitive values (card, account, or routing numbers stored as a username), so
+listing should not dump them. Pass --show-usernames to include the column.
+(The --format json output is an explicit structured opt-in and still emits the
+full metadata, including usernames.)
+
+The -q/--quiet flag is a shorthand for --format simple: it prints bare service
+names, one per line. -q takes precedence over --format.
+
 The --unused flag filters credentials that haven't been accessed recently
 or have never been accessed. Use --days to configure the threshold
 (default: 30 days).
@@ -44,8 +55,14 @@ showing which credentials are used in which projects.
 
 The --location flag filters credentials accessed from a specific directory.
 Use --recursive to include subdirectories.`,
-	Example: `  # List all credentials as table
+	Example: `  # List all credentials as table (usernames hidden)
   pass-cli list
+
+  # Include the username column (may reveal sensitive values)
+  pass-cli list --show-usernames
+
+  # List bare service names, one per line
+  pass-cli list -q
 
   # List as JSON
   pass-cli list --format json
@@ -78,9 +95,11 @@ func init() {
 	listCmd.Flags().StringVarP(&listFormat, "format", "f", "table", "output format: table, json, simple")
 	listCmd.Flags().BoolVar(&listUnused, "unused", false, "show only unused or rarely used credentials")
 	listCmd.Flags().IntVar(&listDays, "days", 30, "days threshold for --unused flag")
-	listCmd.Flags().BoolVar(&listByProject, "by-project", false, "group credentials by git repository")   // T029
-	listCmd.Flags().StringVar(&listLocation, "location", "", "filter credentials by directory path")      // T042
-	listCmd.Flags().BoolVar(&listRecursive, "recursive", false, "include subdirectories with --location") // T043
+	listCmd.Flags().BoolVar(&listByProject, "by-project", false, "group credentials by git repository")              // T029
+	listCmd.Flags().StringVar(&listLocation, "location", "", "filter credentials by directory path")                 // T042
+	listCmd.Flags().BoolVar(&listRecursive, "recursive", false, "include subdirectories with --location")            // T043
+	listCmd.Flags().BoolVar(&listShowUsernames, "show-usernames", false, "include the username column in the table") // #95
+	listCmd.Flags().BoolVarP(&listQuiet, "quiet", "q", false, "print bare service names only (alias for --format simple)")
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -132,11 +151,14 @@ func runList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// #95: -q/--quiet is an alias for --format simple and takes precedence.
+	effectiveFormat := resolveListFormat(listFormat, listQuiet)
+
 	// T030-T034: Handle --by-project mode (User Story 2)
 	// T048: Works with --location (filter first, then group)
 	if listByProject {
 		projects := groupCredentialsByProject(metadata)
-		return outputByProject(projects, listFormat)
+		return outputByProject(projects, effectiveFormat)
 	}
 
 	// Standard list mode (existing behavior)
@@ -146,7 +168,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	})
 
 	// Output in requested format
-	switch strings.ToLower(listFormat) {
+	switch strings.ToLower(effectiveFormat) {
 	case "json":
 		return outputJSON(metadata)
 	case "simple":
@@ -154,8 +176,17 @@ func runList(cmd *cobra.Command, args []string) error {
 	case "table":
 		return outputTable(metadata)
 	default:
-		return fmt.Errorf("invalid format: %s (valid: table, json, simple)", listFormat)
+		return fmt.Errorf("invalid format: %s (valid: table, json, simple)", effectiveFormat)
 	}
+}
+
+// resolveListFormat returns the output format to use. #95: -q/--quiet is a
+// shorthand for "simple" and takes precedence over any --format value.
+func resolveListFormat(format string, quiet bool) string {
+	if quiet {
+		return "simple"
+	}
+	return format
 }
 
 func filterUnused(metadata []vault.CredentialMetadata, days int) []vault.CredentialMetadata {
@@ -258,8 +289,16 @@ func outputTable(metadata []vault.CredentialMetadata) error {
 
 	table := tablewriter.NewWriter(os.Stdout)
 
-	// Prepare header
-	header := []string{"Service", "Username", "Usage", "Last Used", "Created"}
+	// Prepare header.
+	// #95: The Username column is omitted by default because that field can hold
+	// sensitive values (e.g. card/account/routing numbers). It is included only
+	// when --show-usernames is set (omitted entirely, not masked).
+	var header []string
+	if listShowUsernames {
+		header = []string{"Service", "Username", "Usage", "Last Used", "Created"}
+	} else {
+		header = []string{"Service", "Usage", "Last Used", "Created"}
+	}
 
 	// Prepare data rows
 	var data [][]string
@@ -281,19 +320,28 @@ func outputTable(metadata []vault.CredentialMetadata) error {
 		// Format created
 		createdStr := formatRelativeTime(meta.CreatedAt)
 
-		// Truncate username if too long
-		username := meta.Username
-		if len(username) > 30 {
-			username = username[:27] + "..."
-		}
+		if listShowUsernames {
+			// Truncate username if too long
+			username := meta.Username
+			if len(username) > 30 {
+				username = username[:27] + "..."
+			}
 
-		data = append(data, []string{
-			meta.Service,
-			username,
-			usageStr,
-			lastUsedStr,
-			createdStr,
-		})
+			data = append(data, []string{
+				meta.Service,
+				username,
+				usageStr,
+				lastUsedStr,
+				createdStr,
+			})
+		} else {
+			data = append(data, []string{
+				meta.Service,
+				usageStr,
+				lastUsedStr,
+				createdStr,
+			})
+		}
 	}
 
 	// Set table configuration

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/arimxyer/pass-cli/internal/vault"
+)
+
+// captureStdout redirects os.Stdout for the duration of fn and returns whatever
+// was written. The list output functions write directly to os.Stdout, so this is
+// how we observe them.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close pipe writer: %v", err)
+	}
+	os.Stdout = orig
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read captured output: %v", err)
+	}
+	return string(out)
+}
+
+func sampleMetadata() []vault.CredentialMetadata {
+	return []vault.CredentialMetadata{
+		{Service: "github", Username: "4111-1111-1111-1111", UsageCount: 0},
+		{Service: "aws", Username: "routing-021000021", UsageCount: 3},
+	}
+}
+
+// #95: by default the table must NOT include the USERNAME column, because the
+// username field can hold sensitive values.
+func TestOutputTable_HidesUsernameByDefault(t *testing.T) {
+	defer func() { listShowUsernames = false }()
+	listShowUsernames = false
+
+	out := captureStdout(t, func() {
+		if err := outputTable(sampleMetadata()); err != nil {
+			t.Fatalf("outputTable returned error: %v", err)
+		}
+	})
+
+	upper := strings.ToUpper(out)
+	if strings.Contains(upper, "USERNAME") {
+		t.Errorf("default table must not contain a USERNAME header; got:\n%s", out)
+	}
+	// The sensitive username values themselves must not leak into the table.
+	if strings.Contains(out, "4111-1111-1111-1111") || strings.Contains(out, "routing-021000021") {
+		t.Errorf("default table leaked a username value; got:\n%s", out)
+	}
+	// Sanity: the service names should still be present.
+	if !strings.Contains(out, "github") || !strings.Contains(out, "aws") {
+		t.Errorf("expected service names in table output; got:\n%s", out)
+	}
+}
+
+// #95: --show-usernames reintroduces the USERNAME column.
+func TestOutputTable_ShowUsernamesAddsColumn(t *testing.T) {
+	defer func() { listShowUsernames = false }()
+	listShowUsernames = true
+
+	out := captureStdout(t, func() {
+		if err := outputTable(sampleMetadata()); err != nil {
+			t.Fatalf("outputTable returned error: %v", err)
+		}
+	})
+
+	upper := strings.ToUpper(out)
+	if !strings.Contains(upper, "USERNAME") {
+		t.Errorf("--show-usernames must add a USERNAME header; got:\n%s", out)
+	}
+	if !strings.Contains(out, "4111-1111-1111-1111") {
+		t.Errorf("--show-usernames must show username values; got:\n%s", out)
+	}
+}
+
+// #95: -q/--quiet prints bare service names, one per line, and ignores --format.
+func TestQuietOutputsBareServiceNames(t *testing.T) {
+	metadata := sampleMetadata()
+
+	out := captureStdout(t, func() {
+		if err := outputSimple(metadata); err != nil {
+			t.Fatalf("outputSimple returned error: %v", err)
+		}
+	})
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != len(metadata) {
+		t.Fatalf("expected %d lines, got %d: %q", len(metadata), len(lines), out)
+	}
+	for i, meta := range metadata {
+		if lines[i] != meta.Service {
+			t.Errorf("line %d: expected bare service %q, got %q", i, meta.Service, lines[i])
+		}
+	}
+	// Quiet output must never contain table chrome or usernames.
+	if strings.Contains(out, "Usage") || strings.Contains(out, "Created") {
+		t.Errorf("quiet output must not contain table headers; got:\n%s", out)
+	}
+	if strings.Contains(out, "4111-1111-1111-1111") {
+		t.Errorf("quiet output leaked a username value; got:\n%s", out)
+	}
+}
+
+// #95: -q takes precedence over --format. Exercises the shipped resolveListFormat
+// helper that runList uses for dispatch.
+func TestQuietTakesPrecedenceOverFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		quiet  bool
+		want   string
+	}{
+		{name: "quiet overrides table", format: "table", quiet: true, want: "simple"},
+		{name: "quiet overrides json", format: "json", quiet: true, want: "simple"},
+		{name: "no quiet keeps table", format: "table", quiet: false, want: "table"},
+		{name: "no quiet keeps json", format: "json", quiet: false, want: "json"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveListFormat(tt.format, tt.quiet); got != tt.want {
+				t.Errorf("resolveListFormat(%q, %v) = %q, want %q", tt.format, tt.quiet, got, tt.want)
+			}
+		})
+	}
+}
+
+// #95: the -q/--quiet and --show-usernames flags are registered on the list command.
+func TestListFlagsRegistered(t *testing.T) {
+	if listCmd.Flags().Lookup("show-usernames") == nil {
+		t.Error("--show-usernames flag should be registered on list")
+	}
+	q := listCmd.Flags().ShorthandLookup("q")
+	if q == nil {
+		t.Error("-q shorthand should be registered on list")
+	} else if q.Name != "quiet" {
+		t.Errorf("-q shorthand should map to --quiet, got %q", q.Name)
+	}
+}


### PR DESCRIPTION
## Summary

`pass-cli list`'s default table printed the **Username** column, whose values can be sensitive — card / account / routing numbers are commonly stored as an entry's "username". A broad `list` dumped those into a transcript. This makes listing the *safe* step.

### Changes (cmd/list.go only)
- **Drop the Username column from the default table.** `outputTable` now builds the header and rows conditionally; the column is **omitted entirely** (not masked with asterisks) unless opted in.
- **Add `--show-usernames`** (BoolVar, default false) to reintroduce the column.
- **Add `-q`/`--quiet`** as a documented alias for `--format simple`. `-q` takes precedence over `--format`, routed through a small `resolveListFormat` helper.
- **Docs:** `Long`/`Example` updated to surface `-q` and `--show-usernames`, and to state plainly that usernames are hidden by default because that field can hold sensitive values.

### Deliberately unchanged
- `--format json` still emits full metadata including usernames — it is an explicit, structured opt-in, per the plan.
- No TTY-based auto-default behavior (would break `list | …` pipelines and does nothing for JSON).

### Tests (cmd/list_test.go)
- default table has no `USERNAME` header and leaks no username **values**;
- `--show-usernames` reintroduces the column and its values;
- `-q` prints bare service names one per line;
- `-q` precedence over `--format` (table-driven, exercises the shipped helper);
- flags are registered with the expected names/shorthand.

### Checks
- `gofmt` clean, `go vet ./...` clean, `go test ./...` green, `go build ./...` green.
- golangci-lint v2.5 (matching CI) run via `go run`: **0 issues**.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sxsM218vNzDbuMZ2nhMzx