### PR TITLE
feat(exec): add `pass-cli exec` to inject credentials as env vars

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -36,7 +36,11 @@ There are two ways to map credentials to environment variables:
   pass-cli exec openai-api -- python train.py   # sets OPENAI_API
 
 The -f/--field flag selects which field to inject (default: password) and
-applies to all --set mappings.
+applies to every mapping. A single mapping can override it with a ':field'
+suffix, which is how you inject two fields of the same entry as separate
+variables (e.g. a database username and password):
+
+  pass-cli exec --set DB_USER=postgres:username --set DB_PASSWORD=postgres:password -- ./run.sh
 
 Everything after '--' is the command to run; pass-cli writes nothing of its
 own to stdout, and the child's exit code is propagated unchanged.
@@ -55,6 +59,9 @@ it is not process isolation.`,
   # Inject a non-password field
   pass-cli exec --set DB_USER=postgres --field username -- ./run-migration.sh
 
+  # Inject two fields of one entry as separate variables (per-mapping field override)
+  pass-cli exec --set DB_USER=postgres:username --set DB_PASSWORD=postgres:password -- ./run-migration.sh
+
   # Convenience form: service name -> env name (openai-api -> OPENAI_API)
   pass-cli exec openai-api -- python train.py`,
 	Args: cobra.ArbitraryArgs,
@@ -63,15 +70,17 @@ it is not process isolation.`,
 
 func init() {
 	rootCmd.AddCommand(execCmd)
-	execCmd.Flags().StringArrayVar(&execSets, "set", nil, "map an environment variable to a credential: ENV_NAME=service (repeatable)")
+	execCmd.Flags().StringArrayVar(&execSets, "set", nil, "map an environment variable to a credential: ENV_NAME=service[:field] (repeatable)")
 	execCmd.Flags().StringVarP(&execField, "field", "f", "password", "field to inject for all mappings (username, password, category, url, notes, service)")
 }
 
 // envMapping pairs a target environment variable name with the credential service
-// whose field value should be injected into it.
+// whose field value should be injected into it. field is the optional per-mapping
+// field override ("" means fall back to the global --field flag).
 type envMapping struct {
 	envName string
 	service string
+	field   string
 }
 
 // parseExecArgs splits the parsed positional args into credential mappings and the
@@ -95,11 +104,17 @@ func parseExecArgs(sets []string, args []string, dashIdx int) (mappings []envMap
 			return nil, nil, fmt.Errorf("cannot combine a positional <service> (%q) with --set; use one form or the other", preDash[0])
 		}
 		for _, s := range sets {
-			name, service, ok := strings.Cut(s, "=")
-			if !ok || name == "" || service == "" {
-				return nil, nil, fmt.Errorf("invalid --set value %q: expected ENV_NAME=service", s)
+			name, spec, ok := strings.Cut(s, "=")
+			if !ok || name == "" || spec == "" {
+				return nil, nil, fmt.Errorf("invalid --set value %q: expected ENV_NAME=service[:field]", s)
 			}
-			mappings = append(mappings, envMapping{envName: name, service: service})
+			// Optional per-mapping field override: service:field. The first ':'
+			// separates the service from the field, so a field always wins when present.
+			service, field, hasField := strings.Cut(spec, ":")
+			if hasField && (service == "" || field == "") {
+				return nil, nil, fmt.Errorf("invalid --set value %q: expected ENV_NAME=service:field", s)
+			}
+			mappings = append(mappings, envMapping{envName: name, service: service, field: field})
 		}
 		return mappings, childArgv, nil
 	}
@@ -192,7 +207,12 @@ func runExec(cmd *cobra.Command, args []string) error {
 	// a hot path don't mutate the vault hash and trigger a sync push every time.
 	extraEnv := make([]string, 0, len(mappings))
 	for _, m := range mappings {
-		entry, err := buildEnvEntry(vaultService, m, execField)
+		// A per-mapping field (--set ENV=service:field) overrides the global --field.
+		field := m.field
+		if field == "" {
+			field = execField
+		}
+		entry, err := buildEnvEntry(vaultService, m, field)
 		if err != nil {
 			return err
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/arimxyer/pass-cli/internal/crypto"
+	"github.com/arimxyer/pass-cli/internal/vault"
+)
+
+var (
+	execSets  []string
+	execField string
+)
+
+var execCmd = &cobra.Command{
+	Use:     "exec [<service>] -- <command> [args...]",
+	GroupID: "credentials",
+	Short:   "Run a command with credentials injected as environment variables",
+	Long: `Exec runs a child command with stored credentials injected as environment
+variables. The secret value is passed only through the child process's
+environment - it never touches a file, the clipboard, or your shell history.
+
+There are two ways to map credentials to environment variables:
+
+  # Explicit mapping (repeatable): --set ENV_NAME=service
+  pass-cli exec --set GITHUB_TOKEN=github -- gh repo list
+
+  # Convenience form: derive the env name from the service name
+  # (uppercased, non-alphanumeric characters become '_')
+  pass-cli exec openai-api -- python train.py   # sets OPENAI_API
+
+The -f/--field flag selects which field to inject (default: password) and
+applies to all --set mappings.
+
+Everything after '--' is the command to run; pass-cli writes nothing of its
+own to stdout, and the child's exit code is propagated unchanged.
+
+Security note: the injected value lives in the child process's environment.
+On Linux it is readable via /proc/<pid>/environ by the same user and is
+inherited by descendant processes. This is the same model as 'op run' and
+'aws-vault exec' - far safer than files, clipboards, or shell history, but
+it is not process isolation.`,
+	Example: `  # Inject a password as GITHUB_TOKEN and run gh
+  pass-cli exec --set GITHUB_TOKEN=github -- gh repo list
+
+  # Multiple credentials at once
+  pass-cli exec --set AWS_ACCESS_KEY_ID=aws-id --set AWS_SECRET_ACCESS_KEY=aws-secret -- aws s3 ls
+
+  # Inject a non-password field
+  pass-cli exec --set DB_USER=postgres --field username -- ./run-migration.sh
+
+  # Convenience form: service name -> env name (openai-api -> OPENAI_API)
+  pass-cli exec openai-api -- python train.py`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runExec,
+}
+
+func init() {
+	rootCmd.AddCommand(execCmd)
+	execCmd.Flags().StringArrayVar(&execSets, "set", nil, "map an environment variable to a credential: ENV_NAME=service (repeatable)")
+	execCmd.Flags().StringVarP(&execField, "field", "f", "password", "field to inject for all mappings (username, password, category, url, notes, service)")
+}
+
+// envMapping pairs a target environment variable name with the credential service
+// whose field value should be injected into it.
+type envMapping struct {
+	envName string
+	service string
+}
+
+// parseExecArgs splits the parsed positional args into credential mappings and the
+// child command argv. dashIdx is cmd.ArgsLenAtDash(): the number of positional args
+// that appeared before the "--" terminator (or -1 if there was no "--").
+func parseExecArgs(sets []string, args []string, dashIdx int) (mappings []envMapping, childArgv []string, err error) {
+	var preDash []string
+	if dashIdx < 0 {
+		// No "--" terminator at all: we cannot tell the service from the command.
+		return nil, nil, errors.New("no command to run: separate it with '--', e.g. pass-cli exec --set NAME=service -- mycmd")
+	}
+	preDash = args[:dashIdx]
+	childArgv = args[dashIdx:]
+
+	if len(childArgv) == 0 {
+		return nil, nil, errors.New("no command to run after '--': specify a command, e.g. pass-cli exec --set NAME=service -- mycmd")
+	}
+
+	if len(sets) > 0 {
+		if len(preDash) > 0 {
+			return nil, nil, fmt.Errorf("cannot combine a positional <service> (%q) with --set; use one form or the other", preDash[0])
+		}
+		for _, s := range sets {
+			name, service, ok := strings.Cut(s, "=")
+			if !ok || name == "" || service == "" {
+				return nil, nil, fmt.Errorf("invalid --set value %q: expected ENV_NAME=service", s)
+			}
+			mappings = append(mappings, envMapping{envName: name, service: service})
+		}
+		return mappings, childArgv, nil
+	}
+
+	// Convenience form: a single positional service, env name derived from it.
+	if len(preDash) != 1 {
+		return nil, nil, errors.New("expected exactly one <service> before '--' (or use --set ENV_NAME=service)")
+	}
+	service := preDash[0]
+	envName := deriveEnvName(service)
+	if envName == "" {
+		return nil, nil, fmt.Errorf("cannot derive an environment variable name from service %q; use --set ENV_NAME=%s", service, service)
+	}
+	mappings = append(mappings, envMapping{envName: envName, service: service})
+	return mappings, childArgv, nil
+}
+
+// deriveEnvName converts a service name into an environment variable name:
+// uppercased, with every non-alphanumeric ASCII character replaced by '_'.
+// e.g. "openai-api" -> "OPENAI_API".
+func deriveEnvName(service string) string {
+	var b strings.Builder
+	for _, r := range strings.ToUpper(service) {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+// runChild executes the child process, inheriting the parent's stdio. It returns
+// the child's exit code (0 on success) and a non-nil error only when the child
+// could not be started or completed abnormally (e.g. killed by a signal). This
+// keeps os.Exit out of the runner so exit-code propagation is unit-testable.
+func runChild(childArgv []string, extraEnv []string) (int, error) {
+	c := exec.Command(childArgv[0], childArgv[1:]...) // #nosec G204 - command comes from the user's own argv after '--'
+	c.Env = append(os.Environ(), extraEnv...)
+	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+
+	err := c.Run()
+	if err == nil {
+		return 0, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		code := exitErr.ExitCode()
+		if code < 0 {
+			// Terminated by a signal (no portable exit code); surface as an error.
+			return 0, fmt.Errorf("command %q terminated abnormally: %w", childArgv[0], err)
+		}
+		return code, nil
+	}
+	return 0, fmt.Errorf("failed to execute %q: %w", childArgv[0], err)
+}
+
+func runExec(cmd *cobra.Command, args []string) error {
+	mappings, childArgv, err := parseExecArgs(execSets, args, cmd.ArgsLenAtDash())
+	if err != nil {
+		return err
+	}
+
+	vaultPath := GetVaultPath()
+
+	// Check if vault exists
+	if _, err := os.Stat(vaultPath); os.IsNotExist(err) {
+		return fmt.Errorf("vault not found at %s\nRun 'pass-cli init' to create a vault first", vaultPath)
+	}
+
+	// Create vault service
+	vaultService, err := vault.New(vaultPath)
+	if err != nil {
+		return fmt.Errorf("failed to create vault service at %s: %w", vaultPath, err)
+	}
+
+	// Smart sync pull before unlock to get latest version (read-only: no push after)
+	syncPullBeforeUnlock(vaultService)
+
+	// Unlock vault
+	if err := unlockVault(vaultService); err != nil {
+		return err
+	}
+	defer vaultService.Lock()
+
+	// Build the child's extra environment. exec is deliberately read-only: it does
+	// NOT call RecordFieldAccess or syncPushAfterCommand, so repeated invocations on
+	// a hot path don't mutate the vault hash and trigger a sync push every time.
+	extraEnv := make([]string, 0, len(mappings))
+	for _, m := range mappings {
+		entry, err := buildEnvEntry(vaultService, m, execField)
+		if err != nil {
+			return err
+		}
+		extraEnv = append(extraEnv, entry)
+	}
+
+	exitCode, err := runChild(childArgv, extraEnv)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		// Execute() flattens any returned error to exit 1, so we must propagate the
+		// child's exit code ourselves. Lock explicitly because the deferred Lock will
+		// not run after os.Exit (memory zeroing is moot at process exit).
+		vaultService.Lock()
+		os.Exit(exitCode)
+	}
+	return nil
+}
+
+// buildEnvEntry fetches one credential, resolves the requested field, and returns
+// the "ENV_NAME=value" string. The credential's secret bytes are cleared before the
+// function returns; the field value is read first, so the wiped bytes never affect
+// the returned string.
+func buildEnvEntry(vaultService *vault.VaultService, m envMapping, field string) (string, error) {
+	// GetCredential returns a deep copy, so clearing Password does not touch the vault.
+	cred, err := vaultService.GetCredential(m.service, false)
+	if err != nil {
+		return "", fmt.Errorf("failed to get credential %q: %w", m.service, err)
+	}
+	defer crypto.ClearBytes(cred.Password)
+
+	value, _, err := resolveCredentialField(cred, field)
+	if err != nil {
+		return "", err
+	}
+	return m.envName + "=" + value, nil
+}

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,0 +1,397 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/arimxyer/pass-cli/internal/vault"
+)
+
+// TestResolveCredentialField verifies the shared field resolver covers every alias
+// used by both `get` and `exec`, returns the canonical name, and rejects bad fields.
+func TestResolveCredentialField(t *testing.T) {
+	cred := &vault.Credential{
+		Service:  "github",
+		Username: "octocat",
+		Password: []byte("s3cr3t-pw"),
+		Category: "vcs",
+		URL:      "https://github.com",
+		Notes:    "personal token",
+	}
+
+	tests := []struct {
+		field         string
+		wantValue     string
+		wantCanonical string
+	}{
+		{"username", "octocat", "username"},
+		{"user", "octocat", "username"},
+		{"u", "octocat", "username"},
+		{"password", "s3cr3t-pw", "password"},
+		{"pass", "s3cr3t-pw", "password"},
+		{"p", "s3cr3t-pw", "password"},
+		{"PASSWORD", "s3cr3t-pw", "password"}, // case-insensitive
+		{"category", "vcs", "category"},
+		{"cat", "vcs", "category"},
+		{"c", "vcs", "category"},
+		{"url", "https://github.com", "url"},
+		{"notes", "personal token", "notes"},
+		{"note", "personal token", "notes"},
+		{"n", "personal token", "notes"},
+		{"service", "github", "service"},
+		{"s", "github", "service"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			value, canonical, err := resolveCredentialField(cred, tt.field)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if value != tt.wantValue {
+				t.Errorf("value = %q, want %q", value, tt.wantValue)
+			}
+			if canonical != tt.wantCanonical {
+				t.Errorf("canonical = %q, want %q", canonical, tt.wantCanonical)
+			}
+		})
+	}
+
+	t.Run("invalid field", func(t *testing.T) {
+		_, _, err := resolveCredentialField(cred, "totp")
+		if err == nil {
+			t.Fatal("expected error for invalid field, got nil")
+		}
+	})
+}
+
+// TestDeriveEnvName verifies service -> env var name derivation.
+func TestDeriveEnvName(t *testing.T) {
+	tests := []struct {
+		service string
+		want    string
+	}{
+		{"openai-api", "OPENAI_API"},
+		{"github", "GITHUB"},
+		{"aws.prod", "AWS_PROD"},
+		{"my service", "MY_SERVICE"},
+		{"api/v2:key", "API_V2_KEY"},
+		{"already_ok", "ALREADY_OK"},
+		{"GH123", "GH123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.service, func(t *testing.T) {
+			if got := deriveEnvName(tt.service); got != tt.want {
+				t.Errorf("deriveEnvName(%q) = %q, want %q", tt.service, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseExecArgs covers the credential-mapping / child-argv split, the
+// convenience form, and every error path, using a hand-set dash index.
+func TestParseExecArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		sets         []string
+		args         []string
+		dashIdx      int
+		wantMappings []envMapping
+		wantChild    []string
+		wantErr      bool
+	}{
+		{
+			name:         "single --set mapping",
+			sets:         []string{"GITHUB_TOKEN=github"},
+			args:         []string{"gh", "repo", "list"},
+			dashIdx:      0,
+			wantMappings: []envMapping{{"GITHUB_TOKEN", "github"}},
+			wantChild:    []string{"gh", "repo", "list"},
+		},
+		{
+			name:         "multiple --set mappings",
+			sets:         []string{"AWS_ACCESS_KEY_ID=aws-id", "AWS_SECRET_ACCESS_KEY=aws-secret"},
+			args:         []string{"aws", "s3", "ls"},
+			dashIdx:      0,
+			wantMappings: []envMapping{{"AWS_ACCESS_KEY_ID", "aws-id"}, {"AWS_SECRET_ACCESS_KEY", "aws-secret"}},
+			wantChild:    []string{"aws", "s3", "ls"},
+		},
+		{
+			name:         "convenience form derives env name",
+			sets:         nil,
+			args:         []string{"openai-api", "python", "train.py"},
+			dashIdx:      1,
+			wantMappings: []envMapping{{"OPENAI_API", "openai-api"}},
+			wantChild:    []string{"python", "train.py"},
+		},
+		{
+			name:    "missing -- terminator",
+			sets:    []string{"K=svc"},
+			args:    []string{"mycmd"},
+			dashIdx: -1,
+			wantErr: true,
+		},
+		{
+			name:    "no command after --",
+			sets:    []string{"K=svc"},
+			args:    []string{},
+			dashIdx: 0,
+			wantErr: true,
+		},
+		{
+			name:    "positional service combined with --set",
+			sets:    []string{"K=svc"},
+			args:    []string{"extra", "mycmd"},
+			dashIdx: 1,
+			wantErr: true,
+		},
+		{
+			name:    "invalid --set value (no =)",
+			sets:    []string{"NOEQUALS"},
+			args:    []string{"mycmd"},
+			dashIdx: 0,
+			wantErr: true,
+		},
+		{
+			name:    "invalid --set value (empty service)",
+			sets:    []string{"K="},
+			args:    []string{"mycmd"},
+			dashIdx: 0,
+			wantErr: true,
+		},
+		{
+			name:    "convenience form with multiple positionals",
+			sets:    nil,
+			args:    []string{"a", "b", "mycmd"},
+			dashIdx: 2,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mappings, child, err := parseExecArgs(tt.sets, tt.args, tt.dashIdx)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got mappings=%v child=%v", mappings, child)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equalMappings(mappings, tt.wantMappings) {
+				t.Errorf("mappings = %v, want %v", mappings, tt.wantMappings)
+			}
+			if !equalStrings(child, tt.wantChild) {
+				t.Errorf("child argv = %v, want %v", child, tt.wantChild)
+			}
+		})
+	}
+}
+
+// TestExecCmd_ArgsLenAtDash verifies the real cobra parse path: that the dash index
+// returned by cmd.ArgsLenAtDash() splits the positional args exactly where
+// parseExecArgs assumes. This pins our one external assumption empirically.
+func TestExecCmd_ArgsLenAtDash(t *testing.T) {
+	parse := func(argv []string) (mappings []envMapping, child []string, parseErr, execErr error) {
+		var sets []string
+		c := &cobra.Command{
+			Use:  "exec",
+			Args: cobra.ArbitraryArgs,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				mappings, child, parseErr = parseExecArgs(sets, args, cmd.ArgsLenAtDash())
+				return nil
+			},
+		}
+		c.Flags().StringArrayVar(&sets, "set", nil, "")
+		c.Flags().StringP("field", "f", "password", "")
+		c.SetArgs(argv)
+		c.SetOut(io.Discard)
+		c.SetErr(io.Discard)
+		execErr = c.Execute()
+		return
+	}
+
+	t.Run("set form splits at --", func(t *testing.T) {
+		mappings, child, parseErr, execErr := parse([]string{"--set", "K=svc", "--", "mycmd", "arg1"})
+		if execErr != nil || parseErr != nil {
+			t.Fatalf("execErr=%v parseErr=%v", execErr, parseErr)
+		}
+		if !equalMappings(mappings, []envMapping{{"K", "svc"}}) {
+			t.Errorf("mappings = %v", mappings)
+		}
+		if !equalStrings(child, []string{"mycmd", "arg1"}) {
+			t.Errorf("child = %v, want [mycmd arg1]", child)
+		}
+	})
+
+	t.Run("convenience form splits at --", func(t *testing.T) {
+		mappings, child, parseErr, execErr := parse([]string{"svc", "--", "mycmd"})
+		if execErr != nil || parseErr != nil {
+			t.Fatalf("execErr=%v parseErr=%v", execErr, parseErr)
+		}
+		if !equalMappings(mappings, []envMapping{{"SVC", "svc"}}) {
+			t.Errorf("mappings = %v", mappings)
+		}
+		if !equalStrings(child, []string{"mycmd"}) {
+			t.Errorf("child = %v, want [mycmd]", child)
+		}
+	})
+
+	t.Run("child flags after -- are not parsed as exec flags", func(t *testing.T) {
+		mappings, child, parseErr, execErr := parse([]string{"--set", "K=svc", "--", "mycmd", "--child-flag", "v"})
+		if execErr != nil || parseErr != nil {
+			t.Fatalf("execErr=%v parseErr=%v", execErr, parseErr)
+		}
+		if !equalMappings(mappings, []envMapping{{"K", "svc"}}) {
+			t.Errorf("mappings = %v", mappings)
+		}
+		if !equalStrings(child, []string{"mycmd", "--child-flag", "v"}) {
+			t.Errorf("child = %v", child)
+		}
+	})
+
+	t.Run("missing -- surfaces parse error", func(t *testing.T) {
+		_, _, parseErr, execErr := parse([]string{"--set", "K=svc", "mycmd"})
+		if execErr != nil {
+			t.Fatalf("execErr=%v", execErr)
+		}
+		if parseErr == nil {
+			t.Fatal("expected parse error for missing --, got nil")
+		}
+	})
+}
+
+// TestRunChild_ExitCodePropagation verifies the child's non-zero exit code is
+// returned unchanged (this is the value runExec then passes to os.Exit).
+func TestRunChild_ExitCodePropagation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh; covered end-to-end by the integration suite")
+	}
+
+	code, err := runChild([]string{"sh", "-c", "exit 7"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 7 {
+		t.Errorf("exit code = %d, want 7", code)
+	}
+}
+
+// TestRunChild_Success verifies a clean child exit yields code 0 and no error.
+func TestRunChild_Success(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh; covered end-to-end by the integration suite")
+	}
+
+	code, err := runChild([]string{"sh", "-c", "exit 0"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+}
+
+// TestRunChild_EnvInjectionAndStdoutNoSecret verifies that the injected env var
+// reaches the child, and that pass-cli itself writes nothing of its own to stdout:
+// when the child does not echo the secret, the secret never appears on stdout.
+func TestRunChild_EnvInjectionAndStdoutNoSecret(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh; covered end-to-end by the integration suite")
+	}
+
+	const secret = "super-secret-value-xyz"
+
+	// Sub-case 1: child echoes the env var -> proves injection works.
+	out := captureStdout(t, func() {
+		code, err := runChild([]string{"sh", "-c", `printf %s "$MYVAR"`}, []string{"MYVAR=" + secret})
+		if err != nil || code != 0 {
+			t.Fatalf("runChild failed: code=%d err=%v", code, err)
+		}
+	})
+	if out != secret {
+		t.Errorf("env injection: stdout = %q, want %q", out, secret)
+	}
+
+	// Sub-case 2: child does NOT echo the secret -> stdout has only child output,
+	// and the secret never appears (pass-cli prints nothing of its own).
+	out = captureStdout(t, func() {
+		code, err := runChild([]string{"sh", "-c", "echo CHILD_RAN"}, []string{"MYVAR=" + secret})
+		if err != nil || code != 0 {
+			t.Fatalf("runChild failed: code=%d err=%v", code, err)
+		}
+	})
+	if got := trimNewline(out); got != "CHILD_RAN" {
+		t.Errorf("stdout = %q, want %q", got, "CHILD_RAN")
+	}
+	if bytes.Contains([]byte(out), []byte(secret)) {
+		t.Errorf("secret leaked to stdout: %q", out)
+	}
+}
+
+// --- test helpers ---
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = orig
+	out := <-done
+	_ = r.Close()
+	return out
+}
+
+func trimNewline(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+func equalMappings(a, b []envMapping) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -111,7 +111,7 @@ func TestParseExecArgs(t *testing.T) {
 			sets:         []string{"GITHUB_TOKEN=github"},
 			args:         []string{"gh", "repo", "list"},
 			dashIdx:      0,
-			wantMappings: []envMapping{{"GITHUB_TOKEN", "github"}},
+			wantMappings: []envMapping{{"GITHUB_TOKEN", "github", ""}},
 			wantChild:    []string{"gh", "repo", "list"},
 		},
 		{
@@ -119,7 +119,7 @@ func TestParseExecArgs(t *testing.T) {
 			sets:         []string{"AWS_ACCESS_KEY_ID=aws-id", "AWS_SECRET_ACCESS_KEY=aws-secret"},
 			args:         []string{"aws", "s3", "ls"},
 			dashIdx:      0,
-			wantMappings: []envMapping{{"AWS_ACCESS_KEY_ID", "aws-id"}, {"AWS_SECRET_ACCESS_KEY", "aws-secret"}},
+			wantMappings: []envMapping{{"AWS_ACCESS_KEY_ID", "aws-id", ""}, {"AWS_SECRET_ACCESS_KEY", "aws-secret", ""}},
 			wantChild:    []string{"aws", "s3", "ls"},
 		},
 		{
@@ -127,8 +127,38 @@ func TestParseExecArgs(t *testing.T) {
 			sets:         nil,
 			args:         []string{"openai-api", "python", "train.py"},
 			dashIdx:      1,
-			wantMappings: []envMapping{{"OPENAI_API", "openai-api"}},
+			wantMappings: []envMapping{{"OPENAI_API", "openai-api", ""}},
 			wantChild:    []string{"python", "train.py"},
+		},
+		{
+			name:         "per-mapping field override",
+			sets:         []string{"DB_USER=postgres:username"},
+			args:         []string{"mycmd"},
+			dashIdx:      0,
+			wantMappings: []envMapping{{"DB_USER", "postgres", "username"}},
+			wantChild:    []string{"mycmd"},
+		},
+		{
+			name:         "two fields of one entry as separate vars",
+			sets:         []string{"DB_USER=pg:username", "DB_PASSWORD=pg:password"},
+			args:         []string{"./run.sh"},
+			dashIdx:      0,
+			wantMappings: []envMapping{{"DB_USER", "pg", "username"}, {"DB_PASSWORD", "pg", "password"}},
+			wantChild:    []string{"./run.sh"},
+		},
+		{
+			name:    "empty field after colon",
+			sets:    []string{"K=svc:"},
+			args:    []string{"mycmd"},
+			dashIdx: 0,
+			wantErr: true,
+		},
+		{
+			name:    "empty service before colon",
+			sets:    []string{"K=:username"},
+			args:    []string{"mycmd"},
+			dashIdx: 0,
+			wantErr: true,
 		},
 		{
 			name:    "missing -- terminator",
@@ -224,7 +254,7 @@ func TestExecCmd_ArgsLenAtDash(t *testing.T) {
 		if execErr != nil || parseErr != nil {
 			t.Fatalf("execErr=%v parseErr=%v", execErr, parseErr)
 		}
-		if !equalMappings(mappings, []envMapping{{"K", "svc"}}) {
+		if !equalMappings(mappings, []envMapping{{"K", "svc", ""}}) {
 			t.Errorf("mappings = %v", mappings)
 		}
 		if !equalStrings(child, []string{"mycmd", "arg1"}) {
@@ -237,7 +267,7 @@ func TestExecCmd_ArgsLenAtDash(t *testing.T) {
 		if execErr != nil || parseErr != nil {
 			t.Fatalf("execErr=%v parseErr=%v", execErr, parseErr)
 		}
-		if !equalMappings(mappings, []envMapping{{"SVC", "svc"}}) {
+		if !equalMappings(mappings, []envMapping{{"SVC", "svc", ""}}) {
 			t.Errorf("mappings = %v", mappings)
 		}
 		if !equalStrings(child, []string{"mycmd"}) {
@@ -250,7 +280,7 @@ func TestExecCmd_ArgsLenAtDash(t *testing.T) {
 		if execErr != nil || parseErr != nil {
 			t.Fatalf("execErr=%v parseErr=%v", execErr, parseErr)
 		}
-		if !equalMappings(mappings, []envMapping{{"K", "svc"}}) {
+		if !equalMappings(mappings, []envMapping{{"K", "svc", ""}}) {
 			t.Errorf("mappings = %v", mappings)
 		}
 		if !equalStrings(child, []string{"mycmd", "--child-flag", "v"}) {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -141,31 +141,10 @@ func runGet(cmd *cobra.Command, args []string) error {
 }
 
 func outputQuietMode(cred *vault.Credential, vaultService *vault.VaultService, service string) error {
-	field := strings.ToLower(getField)
-	var value string
-	var fieldName string
-
-	switch field {
-	case "username", "user", "u":
-		value = cred.Username
-		fieldName = "username"
-	case "password", "pass", "p":
-		value = string(cred.Password) // T020d: Convert []byte to string
-		fieldName = "password"
-	case "category", "cat", "c":
-		value = cred.Category
-		fieldName = "category"
-	case "url":
-		value = cred.URL
-		fieldName = "url"
-	case "notes", "note", "n":
-		value = cred.Notes
-		fieldName = "notes"
-	case "service", "s":
-		value = cred.Service
-		fieldName = "service"
-	default:
-		return fmt.Errorf("invalid field: %s (valid: username, password, category, url, notes, service)", getField)
+	// Shared field resolver keeps the valid-field list in sync with `exec`.
+	value, fieldName, err := resolveCredentialField(cred, getField)
+	if err != nil {
+		return err
 	}
 
 	// Track field access

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -268,6 +268,33 @@ func formatUsageTable(records []vault.UsageRecord) string {
 	return builder.String()
 }
 
+// resolveCredentialField returns the requested field's value from a credential
+// along with its canonical name (for usage tracking). It is the single source of
+// truth for the field aliases accepted by `get` and `exec`, keeping the valid-field
+// list from drifting between the two commands.
+//
+// Security note: for the password field this returns string(cred.Password); the
+// caller is responsible for clearing the source []byte (crypto.ClearBytes) and for
+// never printing or copying the value where the brief forbids it.
+func resolveCredentialField(cred *vault.Credential, field string) (value string, canonical string, err error) {
+	switch strings.ToLower(field) {
+	case "username", "user", "u":
+		return cred.Username, "username", nil
+	case "password", "pass", "p":
+		return string(cred.Password), "password", nil
+	case "category", "cat", "c":
+		return cred.Category, "category", nil
+	case "url":
+		return cred.URL, "url", nil
+	case "notes", "note", "n":
+		return cred.Notes, "notes", nil
+	case "service", "s":
+		return cred.Service, "service", nil
+	default:
+		return "", "", fmt.Errorf("invalid field: %s (valid: username, password, category, url, notes, service)", field)
+	}
+}
+
 // initVaultAndStorage initializes vault service and returns both vault and storage services
 // This pattern is common across backup commands to avoid code duplication
 func initVaultAndStorage(vaultPath string) (*vault.VaultService, error) {

--- a/test/integration/exec_test.go
+++ b/test/integration/exec_test.go
@@ -1,0 +1,170 @@
+//go:build integration
+
+package integration
+
+import (
+	"errors"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/arimxyer/pass-cli/test/helpers"
+)
+
+// setupExecVault initializes a fresh vault with one known credential and returns
+// the config path, the master password, the service name, and the secret value.
+func setupExecVault(t *testing.T) (configPath, password, service, secret string) {
+	t.Helper()
+
+	password = "Exec-Master-Pass@123"
+	service = "exectest"
+	secret = "super-secret-exec-value-xyz"
+
+	vaultPath := helpers.SetupTestVault(t)
+	configPath, cleanup := helpers.SetupTestVaultConfig(t, vaultPath)
+	t.Cleanup(cleanup)
+
+	// Initialize the vault (declines keychain, so exec prompts for the password).
+	initStdin := helpers.BuildInitStdin(helpers.DefaultInitOptions(password))
+	if _, stderr, err := helpers.RunCmd(t, binaryPath, configPath, initStdin, "init"); err != nil {
+		t.Fatalf("init failed: %v\nStderr: %s", err, stderr)
+	}
+
+	// Add a credential whose password is the secret we will inject.
+	addStdin := helpers.BuildUnlockStdin(password)
+	if _, stderr, err := helpers.RunCmd(t, binaryPath, configPath, addStdin,
+		"add", service, "--username", "execuser", "--password", secret); err != nil {
+		t.Fatalf("add failed: %v\nStderr: %s", err, stderr)
+	}
+
+	return configPath, password, service, secret
+}
+
+// exitCode extracts the process exit code from a *exec.ExitError (or -1).
+func exitCode(err error) int {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+// TestIntegration_Exec_ExitCodePropagation verifies pass-cli exits with the child's
+// exit code (this is the end-to-end pin for runExec's os.Exit call).
+func TestIntegration_Exec_ExitCodePropagation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh")
+	}
+
+	configPath, password, service, _ := setupExecVault(t)
+
+	stdin := helpers.BuildUnlockStdin(password)
+	stdout, stderr, err := helpers.RunCmd(t, binaryPath, configPath, stdin,
+		"exec", "--set", "K="+service, "--", "sh", "-c", "exit 7")
+
+	if err == nil {
+		t.Fatalf("expected non-zero exit, got success\nStdout: %s\nStderr: %s", stdout, stderr)
+	}
+	if code := exitCode(err); code != 7 {
+		t.Errorf("exit code = %d, want 7\nStderr: %s", code, stderr)
+	}
+}
+
+// TestIntegration_Exec_EnvInjection verifies the secret reaches the child process
+// environment under the requested variable name.
+func TestIntegration_Exec_EnvInjection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh")
+	}
+
+	configPath, password, service, secret := setupExecVault(t)
+
+	stdin := helpers.BuildUnlockStdin(password)
+	stdout, stderr, err := helpers.RunCmd(t, binaryPath, configPath, stdin,
+		"exec", "--set", "MY_TOKEN="+service, "--", "sh", "-c", `printf %s "$MY_TOKEN"`)
+	if err != nil {
+		t.Fatalf("exec failed: %v\nStderr: %s", err, stderr)
+	}
+	if strings.TrimSpace(stdout) != secret {
+		t.Errorf("injected value: stdout = %q, want %q", strings.TrimSpace(stdout), secret)
+	}
+}
+
+// TestIntegration_Exec_StdoutHasNoSecret verifies that when the child does not echo
+// the secret, pass-cli writes nothing of its own to stdout - the secret never leaks.
+func TestIntegration_Exec_StdoutHasNoSecret(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh")
+	}
+
+	configPath, password, service, secret := setupExecVault(t)
+
+	stdin := helpers.BuildUnlockStdin(password)
+	stdout, stderr, err := helpers.RunCmd(t, binaryPath, configPath, stdin,
+		"exec", "--set", "MY_TOKEN="+service, "--", "sh", "-c", "echo CHILD_RAN")
+	if err != nil {
+		t.Fatalf("exec failed: %v\nStderr: %s", err, stderr)
+	}
+	if strings.TrimSpace(stdout) != "CHILD_RAN" {
+		t.Errorf("stdout = %q, want CHILD_RAN", strings.TrimSpace(stdout))
+	}
+	if strings.Contains(stdout, secret) {
+		t.Errorf("secret leaked to stdout: %q", stdout)
+	}
+}
+
+// TestIntegration_Exec_ConvenienceForm verifies the `exec <service> -- cmd` form
+// derives the env name from the service name (exectest -> EXECTEST).
+func TestIntegration_Exec_ConvenienceForm(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh")
+	}
+
+	configPath, password, service, secret := setupExecVault(t)
+
+	stdin := helpers.BuildUnlockStdin(password)
+	stdout, stderr, err := helpers.RunCmd(t, binaryPath, configPath, stdin,
+		"exec", service, "--", "sh", "-c", `printf %s "$EXECTEST"`)
+	if err != nil {
+		t.Fatalf("exec failed: %v\nStderr: %s", err, stderr)
+	}
+	if strings.TrimSpace(stdout) != secret {
+		t.Errorf("convenience-form injection: stdout = %q, want %q", strings.TrimSpace(stdout), secret)
+	}
+}
+
+// TestIntegration_Exec_FieldSelection verifies -f/--field selects a non-password field.
+func TestIntegration_Exec_FieldSelection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh")
+	}
+
+	configPath, password, service, _ := setupExecVault(t)
+
+	stdin := helpers.BuildUnlockStdin(password)
+	stdout, stderr, err := helpers.RunCmd(t, binaryPath, configPath, stdin,
+		"exec", "--set", "DB_USER="+service, "--field", "username", "--", "sh", "-c", `printf %s "$DB_USER"`)
+	if err != nil {
+		t.Fatalf("exec failed: %v\nStderr: %s", err, stderr)
+	}
+	if strings.TrimSpace(stdout) != "execuser" {
+		t.Errorf("field selection: stdout = %q, want execuser", strings.TrimSpace(stdout))
+	}
+}
+
+// TestIntegration_Exec_MissingDashTerminator verifies a clear error when no "--"
+// separates the command.
+func TestIntegration_Exec_MissingDashTerminator(t *testing.T) {
+	configPath, password, service, _ := setupExecVault(t)
+
+	stdin := helpers.BuildUnlockStdin(password)
+	stdout, stderr, err := helpers.RunCmd(t, binaryPath, configPath, stdin,
+		"exec", "--set", "K="+service, "somecmd")
+	if err == nil {
+		t.Fatalf("expected error for missing --, got success\nStdout: %s\nStderr: %s", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "--") {
+		t.Errorf("expected error mentioning '--', got stderr: %s", stderr)
+	}
+}

--- a/test/integration/exec_test.go
+++ b/test/integration/exec_test.go
@@ -153,6 +153,32 @@ func TestIntegration_Exec_FieldSelection(t *testing.T) {
 	}
 }
 
+// TestIntegration_Exec_PerMappingField verifies that two fields of the SAME entry
+// can be injected as separate variables via the service:field override — the
+// database-credentials case (DB_USER + DB_PASSWORD from one entry) that a single
+// global --field cannot express.
+func TestIntegration_Exec_PerMappingField(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh")
+	}
+
+	configPath, password, service, secret := setupExecVault(t)
+
+	stdin := helpers.BuildUnlockStdin(password)
+	stdout, stderr, err := helpers.RunCmd(t, binaryPath, configPath, stdin,
+		"exec",
+		"--set", "DB_USER="+service+":username",
+		"--set", "DB_PASSWORD="+service+":password",
+		"--", "sh", "-c", `printf '%s:%s' "$DB_USER" "$DB_PASSWORD"`)
+	if err != nil {
+		t.Fatalf("exec failed: %v\nStderr: %s", err, stderr)
+	}
+	want := "execuser:" + secret
+	if strings.TrimSpace(stdout) != want {
+		t.Errorf("per-mapping field: stdout = %q, want %q", strings.TrimSpace(stdout), want)
+	}
+}
+
 // TestIntegration_Exec_MissingDashTerminator verifies a clear error when no "--"
 // separates the command.
 func TestIntegration_Exec_MissingDashTerminator(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds `pass-cli exec` (#94): a subcommand that runs a child process with stored credentials injected as environment variables, so the secret never touches a file, the clipboard, or shell history. This closes the leak path where the only way to hand a secret to a child was shell command substitution (`KEY="$(pass-cli get x --quiet)"`), which leaks under `set -x`, CI logs, or file-watching tools.

```bash
# Explicit mapping (repeatable)
pass-cli exec --set GITHUB_TOKEN=github -- gh repo list

# Convenience form: env name derived from service (openai-api -> OPENAI_API)
pass-cli exec openai-api -- python train.py

# Non-password field
pass-cli exec --set DB_USER=postgres --field username -- ./run-migration.sh
```

## Design notes

- **Read-only / side-effect-free:** unlike `get`, `exec` deliberately skips `RecordFieldAccess` and `syncPushAfterCommand`. It targets scripts/agents on a hot path; per-run usage writes would mutate the vault hash and trigger a sync push on every invocation. (`syncPullBeforeUnlock` is kept, matching the specified vault flow.)
- **Exit-code propagation:** `Execute()` flattens any returned error to exit 1, so `runExec` propagates the child's code itself via `os.Exit(code)`. The child-runner (`runChild`) returns `(code, error)` and keeps `os.Exit` out of itself so the mechanism is unit-testable; `runExec` owns the single `os.Exit` call.
- **Windows-safe:** uses `exec.Command`, not `syscall.Exec` (the latter is a runtime `EWINDOWS` stub on Windows, which pass-cli supports).
- **Secret handling:** never prints or clipboards the value; clears the credential's secret `[]byte` with `crypto.ClearBytes` (deferred) after building each env string.
- **Shared field resolver:** the field-selection switch previously inline in `get`'s `outputQuietMode` is extracted to `resolveCredentialField` in `cmd/helpers.go` and reused by both commands, so the valid-field/alias list can't drift.

### Honest security note (also in the command's help)

The injected value lives in the child process's environment. On Linux it is readable via `/proc/<pid>/environ` by the same user and is inherited by descendant processes. This is the same model as `op run` / `aws-vault exec` — far safer than files, clipboards, or shell history, but it is not process isolation.

## Tests

- `cmd/exec_test.go` (unit): field resolver + aliases, env-name derivation, arg parsing (multiple mappings, missing `--`, no command after `--`, positional+`--set` conflict, invalid `--set`), an empirical check that cobra's `ArgsLenAtDash()` splits the argv where `parseExecArgs` assumes, `runChild` exit-code propagation, and stdout-has-only-child-output-never-the-secret.
- `test/integration/exec_test.go` (`-tags=integration`, real binary + real vault): end-to-end exit-code propagation (pins `runExec`'s `os.Exit`), env injection, no-secret-on-stdout, convenience form, field selection, and the missing-`--` error.

## Checks

`gofmt`, `go vet`, `golangci-lint` (cmd + integration, 0 issues), `go test ./...`, `go test -tags=integration -run TestIntegration_Exec`, and `go build` all pass. (POSIX-`sh` tests skip on Windows; CI is Linux.)

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sxsM218vNzDbuMZ2nhMzx