### PR TITLE
fix(test): resolve captureStdout redeclaration breaking main

### DIFF
--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,40 +1,15 @@
 package cmd
 
 import (
-	"io"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/arimxyer/pass-cli/internal/vault"
 )
 
-// captureStdout redirects os.Stdout for the duration of fn and returns whatever
-// was written. The list output functions write directly to os.Stdout, so this is
-// how we observe them.
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-
-	orig := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe: %v", err)
-	}
-	os.Stdout = w
-
-	fn()
-
-	if err := w.Close(); err != nil {
-		t.Fatalf("failed to close pipe writer: %v", err)
-	}
-	os.Stdout = orig
-
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("failed to read captured output: %v", err)
-	}
-	return string(out)
-}
+// captureStdout is defined in exec_test.go (same package) and shared across the
+// cmd test suite; it redirects os.Stdout for the duration of fn and returns what
+// was written, which is how the list output functions are observed here.
 
 func sampleMetadata() []vault.CredentialMetadata {
 	return []vault.CredentialMetadata{


### PR DESCRIPTION
## What

`main` is red after merging #97 and #98: both added a `captureStdout` test helper to package `cmd`, so the test package no longer compiles (`captureStdout redeclared in this block` — `cmd/list_test.go:15` vs `cmd/exec_test.go:372`). This broke the **Lint** and **Unit Tests** jobs on the `ffe0d96` push to main.

Each PR passed CI in isolation because neither branch contained the other's test file — the collision only exists once both are on `main`.

## Fix

- Remove the duplicate `captureStdout` from `cmd/list_test.go`; the list tests now use the shared helper from `cmd/exec_test.go` (same package). Kept the exec version because it drains the pipe in a goroutine, avoiding the deadlock the synchronous list version risks on output larger than the pipe buffer.
- Drop the now-unused `io`/`os` imports from `list_test.go`.

## Verified locally (combined tree)

`gofmt` clean · `go vet ./cmd` clean · `go build ./...` ok · `go test ./cmd/` ok · exec+list integration tests ok · `golangci-lint v2.5.0 ./cmd/...` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sxsM218vNzDbuMZ2nhMzx