### PR TITLE
ci: run CI on all PRs so required checks report for non-code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,15 @@ on:
       - 'CONTRIBUTING.md'
       - 'LICENSE'
       - '.gitignore'
+  # NOTE: no paths-ignore here. The required status checks (Lint, Unit Tests,
+  # Build, Integration Tests) are branch-ruleset requirements, so they must
+  # *report* on every PR or the PR can never merge. The jobs below already
+  # short-circuit to success via "Skip if no code changes" when check-changes
+  # finds no Go/build files, so non-code PRs (docs, skills, .gitignore) still
+  # satisfy the required checks in seconds. A workflow-level paths-ignore would
+  # suppress the whole workflow and leave those PRs blocked forever.
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'specs/**'
-      - '.specify/**'
-      - 'CLAUDE.md'
-      - 'CONTRIBUTING.md'
-      - 'LICENSE'
-      - '.gitignore'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

`main`'s ruleset requires **Lint, Unit Tests, Build, Integration Tests (×3)** on every PR. The jobs in `ci.yml` are already built to satisfy this for non-code PRs — each starts with a `Skip if no code changes` step that exits 0 (reporting the check as **passing** in seconds) when `check-changes` finds no Go/build files.

But a workflow-level `pull_request: paths-ignore` (`**.md`, `docs/**`, `.gitignore`, …) **suppressed the whole workflow** for docs/skill/gitignore-only PRs. So the required checks never reported, and those PRs were **blocked forever** — e.g. **#101** (the agent-skill PR: only `.gitignore` + `SKILL.md`).

## Fix

Remove the `pull_request` `paths-ignore`. The workflow now triggers on every PR; `check-changes` + the per-job skip steps still make non-code PRs go green in seconds. The `push` `paths-ignore` is left as-is (post-merge main CI isn't a required gate).

## Self-consistency

This PR only edits `ci.yml` (not in `paths-ignore`), so it triggers the **current** workflow, `check-changes` finds no `.go` changes, every job skips to success → it merges cleanly under the existing rules. After it lands, #101 re-triggers and merges normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)