### PR TITLE
build: add tracked mise.toml so documented tasks work on a fresh clone (#100)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ go.work.sum
 # Build output
 dist/
 build/
+# Local binary produced by `mise run build` / `go build -o pass-cli .`
+/pass-cli
 
 # IDE files
 .vscode/
@@ -54,7 +56,10 @@ Thumbs.db
 .spec-workflow/approvals/
 .github/prompts/
 .spec-workflow/
-mise.toml
+# Note: mise.toml is intentionally tracked so the `mise run …` tasks documented
+# in CLAUDE.md work on a fresh clone (issue #100). Use mise.local.toml for
+# machine-local overrides — that stays untracked.
+mise.local.toml
 
 # Development notes (keep local only)
 n-n-o-*.md

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,51 @@
+[tools]
+go = "1.25"
+
+# Task runner for pass-cli. These mirror the commands CI runs (see
+# .github/workflows/ci.yml) so the workflow documented in CLAUDE.md works as
+# written on a fresh clone. Run `mise tasks` to list, `mise run <name>` to invoke.
+
+[tasks.fmt]
+description = "Format Go source"
+run = "gofmt -w ."
+
+[tasks.fmt-check]
+description = "Check formatting (fails if any file needs gofmt)"
+run = """
+unformatted=$(gofmt -l .)
+if [ -n "$unformatted" ]; then
+  echo "These files need gofmt:"; echo "$unformatted"; exit 1
+fi
+"""
+
+[tasks.vet]
+description = "Run go vet"
+run = "go vet ./..."
+
+[tasks.lint]
+description = "Run golangci-lint (matches CI args)"
+run = "golangci-lint run --timeout=3m --build-tags integration"
+
+[tasks.test]
+description = "Run unit tests"
+run = "go test ./..."
+
+[tasks."test:integration"]
+description = "Run integration tests (build tag: integration)"
+run = "go test -tags=integration -timeout 4m ./test/integration"
+
+[tasks."test:all"]
+description = "Run unit + integration tests"
+depends = ["test", "test:integration"]
+
+[tasks.build]
+description = "Build the pass-cli binary"
+run = "go build -o pass-cli ."
+
+[tasks.git]
+description = "Run git (passthrough; e.g. mise run git status)"
+run = "git"
+
+[tasks.gh]
+description = "Run gh / GitHub CLI (passthrough; e.g. mise run gh pr list)"
+run = "gh"


### PR DESCRIPTION
## What

`CLAUDE.md` instructs contributors and AI agents to drive every build/test/lint operation through `mise run …` tasks, but **`mise.toml` was gitignored** — so the config existed only locally and none of the documented tasks worked on a fresh clone (`mise tasks` printed nothing; `mise run test` was a silent no-op). This was the divergence reported in #100.

## Changes

- **Un-ignore `mise.toml`** (mirroring the `.claude/skills` treatment in #101); keep `mise.local.toml` ignored for machine-local overrides.
- **Add a tracked `mise.toml`** whose tasks shell out to the same `go` / `golangci-lint` commands CI runs (`.github/workflows/ci.yml`):
  `fmt`, `fmt-check`, `vet`, `lint`, `test`, `test:integration`, `test:all`, `build`, plus `git` / `gh` passthroughs.
- **Gitignore the `/pass-cli` binary** that `mise run build` (`go build -o pass-cli .`) drops at the repo root, so it can't be committed by accident.

This is **option A** from the issue (make reality match the documented contract), chosen because `mise` is already a required tool in the project's environment and `CLAUDE.md` is written entirely around `mise run`.

## Verification

`mise tasks` now lists all documented tasks; locally verified green: `mise run build`, `mise run vet`, `mise run fmt-check`, `mise run test`, and `mise run git status` (passthrough). `lint` matches CI's args (`--timeout=3m --build-tags integration`).

Closes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)