### PR TITLE
perf(sync): overlap the PBKDF2 derive with the pull on keychain unlock (#103, Tier 2)

### DIFF
--- a/cmd/concurrent_unlock_test.go
+++ b/cmd/concurrent_unlock_test.go
@@ -80,3 +80,52 @@ func TestUnlockVaultWithSync_PasswordBranchConcurrent(t *testing.T) {
 		t.Error("expected vault to be unlocked after the concurrent password branch")
 	}
 }
+
+// Tier 2: unlockKeychainOverlappingPull runs the pull (goroutine) concurrently
+// with the PBKDF2 derivation (main), joins, then unlocks with the prepared key.
+// Driving it directly with the password (the value a keychain Retrieve would
+// return) exercises the full overlap under `go test -race` without needing a
+// keychain backend. Asserts a correct unlock and that masterPassword was retained
+// (a subsequent save works).
+func TestUnlockKeychainOverlappingPull_Concurrent(t *testing.T) {
+	const masterPassword = "TestPass!1234"
+
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	cfgPath := filepath.Join(tmpDir, "config.yml")
+
+	cfg := "vault_path: " + vaultPath + "\nsync:\n  enabled: true\n  remote: \"mock-remote:bucket\"\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("PASS_CLI_CONFIG", cfgPath)
+
+	initVS, err := vault.New(vaultPath)
+	if err != nil {
+		t.Fatalf("vault.New (init): %v", err)
+	}
+	if err := initVS.Initialize([]byte(masterPassword), false, "", ""); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	vs, err := vault.New(vaultPath)
+	if err != nil {
+		t.Fatalf("vault.New (locked): %v", err)
+	}
+	if !vs.IsSyncEnabled() {
+		t.Fatal("expected sync enabled")
+	}
+
+	setOffline(t, false)
+	setVerbose(t, false)
+
+	if err := unlockKeychainOverlappingPull(vs, []byte(masterPassword)); err != nil {
+		t.Fatalf("unlockKeychainOverlappingPull: %v", err)
+	}
+	if !vs.IsUnlocked() {
+		t.Fatal("expected vault unlocked after Tier 2 overlap")
+	}
+	if err := vs.AddCredential("svc", "user", []byte("secret"), "", "", ""); err != nil {
+		t.Errorf("AddCredential failed (masterPassword not retained?): %v", err)
+	}
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -406,10 +406,10 @@ func unlockVault(vaultService *vault.VaultService) error {
 // Ordering constraint: Unlock reads and decrypts vault.enc in one step, and a pull
 // replaces that file — so the decrypt must run strictly AFTER the pull finishes.
 // Only work that does not touch vault.enc may overlap the pull:
-//   - the master-password prompt touches stdin only → safe to overlap (the win);
-//   - keychain unlock decrypts vault.enc, and keychain users have no prompt to hide
-//     behind, so that path stays sequential (Tier 2, overlapping the Argon2 KDF, is
-//     a deferred follow-up).
+//   - the master-password prompt touches stdin only → safe to overlap (Tier 1);
+//   - keychain unlock decrypts vault.enc, but its expensive PBKDF2 key DERIVATION
+//     touches only the password + pre-read key params, so it overlaps the pull and
+//     we decrypt after the join (Tier 2).
 func unlockVaultWithSync(vaultService *vault.VaultService) error {
 	// No pull to overlap (sync disabled or --offline): today's exact behavior.
 	if IsOffline() || !vaultService.IsSyncEnabled() {
@@ -417,19 +417,14 @@ func unlockVaultWithSync(vaultService *vault.VaultService) error {
 		return unlockVault(vaultService)
 	}
 
-	// Keychain is resolved BEFORE the pull: retrieving the keychain password reads
-	// metadata + the OS keyring but never decrypts vault.enc. There's no human wait
-	// to hide behind, so pull then decrypt sequentially.
+	// Keychain path (Tier 2): retrieving the keychain password reads metadata + the
+	// OS keyring but never decrypts vault.enc. Read the key-derivation params first
+	// (cheap, pre-pull), then overlap the expensive PBKDF2 derivation with the pull,
+	// join, and unlock with the prepared key (which re-derives if the pull brought a
+	// re-keyed vault).
 	if password, err := vaultService.RetrieveKeychainPassword(); err == nil {
 		defer crypto.ClearBytes(password)
-		syncPullBeforeUnlock(vaultService)
-		if err := vaultService.Unlock(password); err != nil {
-			return fmt.Errorf("failed to unlock vault: %w", err)
-		}
-		if IsVerbose() {
-			fmt.Fprintln(os.Stderr, "🔓 Unlocked vault using keychain")
-		}
-		return nil
+		return unlockKeychainOverlappingPull(vaultService, password)
 	}
 
 	// Password path: run the pull concurrently with the prompt, then join before
@@ -470,6 +465,62 @@ func unlockVaultWithSync(vaultService *vault.VaultService) error {
 
 	if err := vaultService.Unlock(password); err != nil {
 		return fmt.Errorf("failed to unlock vault: %w", err)
+	}
+	return nil
+}
+
+// unlockKeychainOverlappingPull runs the keychain unlock (#103 Tier 2): it reads
+// the vault's key-derivation params, starts the sync pull in a goroutine, derives
+// the data key (the expensive PBKDF2 step) on this goroutine so it overlaps the
+// pull, joins, then unlocks with the prepared key — which itself falls back to a
+// full password unlock if the pull brought a re-keyed vault. The caller owns
+// (and clears) password.
+func unlockKeychainOverlappingPull(vaultService *vault.VaultService, password []byte) error {
+	prep, prepErr := vaultService.PrepareUnlock()
+	if prepErr != nil {
+		// Couldn't read key params → fall back to a sequential keychain unlock.
+		syncPullBeforeUnlock(vaultService)
+		if err := vaultService.Unlock(append([]byte(nil), password...)); err != nil {
+			return fmt.Errorf("failed to unlock vault: %w", err)
+		}
+		if IsVerbose() {
+			fmt.Fprintln(os.Stderr, "🔓 Unlocked vault using keychain")
+		}
+		return nil
+	}
+
+	pullDone := make(chan struct{})
+	go func() {
+		defer close(pullDone)
+		_ = vaultService.SyncPull()
+	}()
+
+	// A transient indicator is safe here — no password prompt to corrupt.
+	if IsVerbose() {
+		fmt.Fprintln(os.Stderr, "🔄 Checking remote for vault changes...")
+	} else {
+		fmt.Fprint(os.Stderr, "Checking remote...")
+	}
+	dataKey, deriveErr := prep.DeriveDataKey(password) // PBKDF2 overlaps the pull
+	<-pullDone                                         // join before any decrypt
+	if !IsVerbose() {
+		fmt.Fprint(os.Stderr, "\r\033[K")
+	}
+
+	if vaultService.SyncConflictDetected() {
+		fmt.Fprintln(os.Stderr, "Warning: sync conflict — local and remote vault both changed. Use `pass-cli sync resolve` to choose which version to keep.")
+	}
+
+	if deriveErr != nil {
+		// Derivation failed (e.g. malformed header) → full password unlock.
+		if err := vaultService.Unlock(append([]byte(nil), password...)); err != nil {
+			return fmt.Errorf("failed to unlock vault: %w", err)
+		}
+	} else if err := vaultService.UnlockWithPreparedKey(prep, dataKey, append([]byte(nil), password...)); err != nil {
+		return err
+	}
+	if IsVerbose() {
+		fmt.Fprintln(os.Stderr, "🔓 Unlocked vault using keychain")
 	}
 	return nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -248,10 +249,12 @@ func (s *StorageService) loadVaultV2(encryptedVault *EncryptedVault, password st
 	return plaintext, nil
 }
 
-// LoadVaultWithKey loads and decrypts vault using a provided encryption key
-// Used for recovery when we have the vault recovery key instead of a password
-// Parameters: key (32-byte AES-256 key)
-// Returns: decrypted vault data, error
+// LoadVaultWithKey loads and decrypts the vault using a provided data-decryption
+// key, skipping password-to-key derivation. Used both for recovery (where the key
+// comes from a recovery secret) and for the prepared-key unlock path (#103 Tier 2),
+// where the key was derived ahead of time via DeriveDataKey. For v1 the key is the
+// password-derived key; for v2 it is the unwrapped DEK.
+// Parameters: key (32-byte AES-256 key). Returns: decrypted vault data, error.
 func (s *StorageService) LoadVaultWithKey(key []byte) ([]byte, error) {
 	encryptedVault, err := s.loadEncryptedVault()
 	if err != nil {
@@ -261,10 +264,89 @@ func (s *StorageService) LoadVaultWithKey(key []byte) ([]byte, error) {
 	// Decrypt vault data with provided key (skip password-to-key derivation)
 	plaintext, err := s.cryptoService.Decrypt(encryptedVault.Data, key)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt vault with recovery key: %w", err)
+		return nil, fmt.Errorf("failed to decrypt vault with provided key: %w", err)
 	}
 
 	return plaintext, nil
+}
+
+// PreparedKeyParams carries the key-derivation parameters read from the vault
+// header. They feed DeriveDataKey to compute the data-decryption key ahead of
+// time (concurrently with a sync pull) without touching the ciphertext, and they
+// are compared post-pull to detect a re-key (see vault.UnlockWithPreparedKey).
+type PreparedKeyParams struct {
+	Version         int
+	Salt            []byte
+	Iterations      int
+	WrappedDEK      []byte
+	WrappedDEKNonce []byte
+}
+
+// Equal reports whether two parameter sets would derive the same key against the
+// same ciphertext. Used to detect that the vault was re-keyed (password change or
+// re-key) between reading the params and decrypting.
+func (p PreparedKeyParams) Equal(o PreparedKeyParams) bool {
+	return p.Version == o.Version &&
+		p.Iterations == o.Iterations &&
+		bytes.Equal(p.Salt, o.Salt) &&
+		bytes.Equal(p.WrappedDEK, o.WrappedDEK) &&
+		bytes.Equal(p.WrappedDEKNonce, o.WrappedDEKNonce)
+}
+
+// ReadKeyParams reads the current on-disk key-derivation parameters without
+// decrypting the vault. Cheap; intended to run before a sync pull so the
+// expensive DeriveDataKey can overlap the pull.
+func (s *StorageService) ReadKeyParams() (PreparedKeyParams, error) {
+	encryptedVault, err := s.loadEncryptedVault()
+	if err != nil {
+		return PreparedKeyParams{}, err
+	}
+	m := encryptedVault.Metadata
+	return PreparedKeyParams{
+		Version:         m.Version,
+		Salt:            m.Salt,
+		Iterations:      m.Iterations,
+		WrappedDEK:      m.WrappedDEK,
+		WrappedDEKNonce: m.WrappedDEKNonce,
+	}, nil
+}
+
+// DeriveDataKey computes the vault's data-decryption key from the password and
+// pre-read key parameters WITHOUT reading the ciphertext — so it can run
+// concurrently with a sync pull. The expensive PBKDF2 step happens here.
+//   - v1: the password-derived key decrypts the vault directly.
+//   - v2: derive the password KEK, then unwrap the DEK; the DEK decrypts the vault.
+//
+// The returned key is what LoadVaultWithKey expects. Caller must ClearBytes it.
+func (s *StorageService) DeriveDataKey(password string, p PreparedKeyParams) ([]byte, error) {
+	if p.Version == 2 {
+		if len(p.WrappedDEK) != crypto.KeyLength+16 {
+			return nil, fmt.Errorf("invalid v2 vault: wrapped DEK length mismatch (expected %d, got %d)",
+				crypto.KeyLength+16, len(p.WrappedDEK))
+		}
+		if len(p.WrappedDEKNonce) != crypto.NonceLength {
+			return nil, fmt.Errorf("invalid v2 vault: nonce length mismatch")
+		}
+
+		passwordKEK, err := s.cryptoService.DeriveKey([]byte(password), p.Salt, p.Iterations)
+		if err != nil {
+			return nil, fmt.Errorf("failed to derive key: %w", err)
+		}
+		defer s.cryptoService.ClearKey(passwordKEK)
+
+		dek, err := crypto.UnwrapKey(crypto.WrappedKey{Ciphertext: p.WrappedDEK, Nonce: p.WrappedDEKNonce}, passwordKEK)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unwrap DEK (invalid password?): %w", err)
+		}
+		return dek, nil
+	}
+
+	// v1: the password-derived key is the data key.
+	key, err := s.cryptoService.DeriveKey([]byte(password), p.Salt, p.Iterations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive key: %w", err)
+	}
+	return key, nil
 }
 
 func (s *StorageService) SaveVault(data []byte, password string, callback ProgressCallback) error {

--- a/internal/vault/prepared_unlock_test.go
+++ b/internal/vault/prepared_unlock_test.go
@@ -1,0 +1,134 @@
+package vault
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+const (
+	tier2Pass    = "TestPass!1234"
+	tier2NewPass = "NewPass!5678"
+)
+
+func initVaultForTier2(t *testing.T) (string, *VaultService) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	v, err := New(vaultPath)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := v.Initialize([]byte(tier2Pass), false, "", ""); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	// Initialize does not leave the vault unlocked; unlock so callers can
+	// ChangePassword on the returned service.
+	if err := v.Unlock([]byte(tier2Pass)); err != nil {
+		t.Fatalf("Unlock after init: %v", err)
+	}
+	return vaultPath, v
+}
+
+// Happy path: parameters unchanged since derivation → the prepared key is used,
+// the vault unlocks, masterPassword is retained (a subsequent save works), and it
+// is NOT a recovery unlock.
+func TestUnlockWithPreparedKey_HappyPath(t *testing.T) {
+	vaultPath, _ := initVaultForTier2(t)
+
+	// Fresh, locked service (as a command would have).
+	v, err := New(vaultPath)
+	if err != nil {
+		t.Fatalf("New(locked): %v", err)
+	}
+
+	prep, err := v.PrepareUnlock()
+	if err != nil {
+		t.Fatalf("PrepareUnlock: %v", err)
+	}
+	dataKey, err := prep.DeriveDataKey([]byte(tier2Pass))
+	if err != nil {
+		t.Fatalf("DeriveDataKey: %v", err)
+	}
+
+	if err := v.UnlockWithPreparedKey(prep, dataKey, []byte(tier2Pass)); err != nil {
+		t.Fatalf("UnlockWithPreparedKey: %v", err)
+	}
+	if !v.IsUnlocked() {
+		t.Fatal("expected vault unlocked")
+	}
+	// masterPassword must be retained (not a recovery unlock) so saves work.
+	if err := v.AddCredential("svc", "user", []byte("secret"), "", "", ""); err != nil {
+		t.Errorf("AddCredential after prepared-key unlock failed (masterPassword not retained?): %v", err)
+	}
+	if v.WasUnlockedViaRecovery() {
+		t.Error("prepared-key unlock must not be flagged as a recovery unlock")
+	}
+}
+
+// Re-key fallback: the vault is re-keyed (password change) AFTER the params were
+// captured, so the prepared key is stale. UnlockWithPreparedKey must detect the
+// param mismatch and fall back to a full unlock with the CURRENT password —
+// succeeding, identical to a sequential unlock.
+func TestUnlockWithPreparedKey_RekeyFallsBackToCurrentPassword(t *testing.T) {
+	vaultPath, v1 := initVaultForTier2(t)
+
+	// Capture params + derive against the ORIGINAL key (v1 is unlocked from init).
+	prep, err := v1.PrepareUnlock()
+	if err != nil {
+		t.Fatalf("PrepareUnlock: %v", err)
+	}
+	dataKey, err := prep.DeriveDataKey([]byte(tier2Pass))
+	if err != nil {
+		t.Fatalf("DeriveDataKey: %v", err)
+	}
+
+	// Re-key on disk (new salt + wrapped key) via the still-unlocked v1.
+	if err := v1.ChangePassword([]byte(tier2NewPass)); err != nil {
+		t.Fatalf("ChangePassword: %v", err)
+	}
+
+	// Fresh locked service unlocks with the stale prepared key + the NEW password.
+	v2, err := New(vaultPath)
+	if err != nil {
+		t.Fatalf("New(locked): %v", err)
+	}
+	if err := v2.UnlockWithPreparedKey(prep, dataKey, []byte(tier2NewPass)); err != nil {
+		t.Fatalf("expected fallback unlock to succeed with current password, got: %v", err)
+	}
+	if !v2.IsUnlocked() {
+		t.Fatal("expected vault unlocked via fallback")
+	}
+}
+
+// Security edge (the reason for param-comparison over decrypt-failure): after a
+// remote re-key, a STALE keychain password must fail cleanly at unlock — never
+// unlock-then-break-saves. The param mismatch routes to the fallback, which fails
+// because the stale password can't derive the current key.
+func TestUnlockWithPreparedKey_StalePasswordFailsCleanly(t *testing.T) {
+	vaultPath, v1 := initVaultForTier2(t)
+
+	prep, err := v1.PrepareUnlock()
+	if err != nil {
+		t.Fatalf("PrepareUnlock: %v", err)
+	}
+	dataKey, err := prep.DeriveDataKey([]byte(tier2Pass))
+	if err != nil {
+		t.Fatalf("DeriveDataKey: %v", err)
+	}
+
+	if err := v1.ChangePassword([]byte(tier2NewPass)); err != nil {
+		t.Fatalf("ChangePassword: %v", err)
+	}
+
+	v2, err := New(vaultPath)
+	if err != nil {
+		t.Fatalf("New(locked): %v", err)
+	}
+	// Pass the OLD (now stale) password — must fail, not silently unlock.
+	if err := v2.UnlockWithPreparedKey(prep, dataKey, []byte(tier2Pass)); err == nil {
+		t.Fatal("expected stale-password unlock to fail, but it succeeded")
+	}
+	if v2.IsUnlocked() {
+		t.Error("vault must remain locked after a stale-password unlock attempt")
+	}
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -948,6 +948,78 @@ func (v *VaultService) UnlockWithKey(vaultKey []byte) error {
 	return nil
 }
 
+// PreparedUnlock holds key-derivation parameters captured before a sync pull so
+// the expensive PBKDF2 derivation can overlap the pull (#103 Tier 2). It is
+// produced by PrepareUnlock, derives the data key via DeriveDataKey (safe to run
+// while a pull is in flight), and is consumed by UnlockWithPreparedKey.
+type PreparedUnlock struct {
+	storageService *storage.StorageService
+	params         storage.PreparedKeyParams
+}
+
+// PrepareUnlock reads the current key-derivation parameters (cheap, pre-pull).
+// Call this before kicking off SyncPull, then run DeriveDataKey concurrently with
+// the pull, then UnlockWithPreparedKey after the join.
+func (v *VaultService) PrepareUnlock() (*PreparedUnlock, error) {
+	params, err := v.storageService.ReadKeyParams()
+	if err != nil {
+		return nil, err
+	}
+	return &PreparedUnlock{storageService: v.storageService, params: params}, nil
+}
+
+// DeriveDataKey runs the expensive PBKDF2 derivation against the captured
+// parameters (no file access) — safe to call while a sync pull is in flight.
+// The returned key is handed to UnlockWithPreparedKey, which clears it.
+func (p *PreparedUnlock) DeriveDataKey(password []byte) ([]byte, error) {
+	return p.storageService.DeriveDataKey(string(password), p.params)
+}
+
+// UnlockWithPreparedKey completes a keychain unlock using dataKey derived ahead
+// of time (concurrently with a sync pull). If the vault was re-keyed since the
+// parameters were captured — a password change or re-key on another device that a
+// just-completed pull brought in — the prepared key is stale. That is detected by
+// comparing the current on-disk key parameters against the captured ones; on a
+// mismatch it falls back to a full password unlock, making this path behave
+// identically to a sequential keychain unlock in that edge (e.g. a stale-keychain
+// password fails cleanly at unlock rather than unlocking then breaking saves).
+// A decrypt failure is a belt-and-suspenders second fallback. masterPassword and
+// dataKey are cleared before returning.
+func (v *VaultService) UnlockWithPreparedKey(prep *PreparedUnlock, dataKey, masterPassword []byte) error {
+	defer crypto.ClearBytes(masterPassword)
+	defer crypto.ClearBytes(dataKey)
+
+	if v.unlocked {
+		return nil // Already unlocked
+	}
+
+	if err := v.handleIncompleteMigration(); err != nil {
+		return err
+	}
+
+	// Re-read params from the (possibly pulled) file. If they differ from what we
+	// derived against, the prepared key is stale → full re-derive against current
+	// params, keeping behavior identical to a sequential unlock on any re-key.
+	current, err := v.storageService.ReadKeyParams()
+	preparedKeyUsable := err == nil && prep != nil && prep.params.Equal(current)
+
+	if preparedKeyUsable {
+		if data, decErr := v.storageService.LoadVaultWithKey(dataKey); decErr == nil {
+			return v.finishUnlock(data, masterPassword)
+		}
+		// Belt-and-suspenders: params matched but decrypt unexpectedly failed —
+		// fall through to the password path rather than failing the unlock.
+	}
+
+	// Fallback: full password unlock (re-derives against current params).
+	data, err := v.storageService.LoadVault(string(masterPassword))
+	if err != nil {
+		v.LogAudit(security.EventVaultUnlock, security.OutcomeFailure, "")
+		return fmt.Errorf("failed to unlock vault: %w", err)
+	}
+	return v.finishUnlock(data, masterPassword)
+}
+
 // UnlockWithKeychain attempts to unlock using keychain-stored password
 func (v *VaultService) UnlockWithKeychain() error {
 	password, err := v.RetrieveKeychainPassword()

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -696,54 +696,75 @@ func (v *VaultService) Unlock(masterPassword []byte) error {
 		return nil // Already unlocked
 	}
 
-	// T036e: Check for incomplete migration (vault.tmp exists)
-	vaultTmpPath := v.vaultPath + storage.TempSuffix
-	vaultBackupPath := v.vaultPath + storage.BackupSuffix
-
-	if _, err := os.Stat(vaultTmpPath); err == nil {
-		// T036g: Incomplete migration detected - inform user with actionable message
-		fmt.Fprintf(os.Stderr, "\n*** MIGRATION FAILURE DETECTED ***\n")
-		fmt.Fprintf(os.Stderr, "An incomplete vault migration was found (power loss or system crash).\n")
-
-		if _, err := os.Stat(vaultBackupPath); err == nil {
-			// Backup exists - restore it
-			fmt.Fprintf(os.Stderr, "Attempting automatic recovery from backup...\n")
-
-			// Read backup
-			backupData, err := os.ReadFile(vaultBackupPath) // #nosec G304 -- Vault backup path validated by storage layer
-			if err != nil {
-				return fmt.Errorf("failed to read backup for rollback: %w", err)
-			}
-
-			// Restore to main vault path
-			if err := os.WriteFile(v.vaultPath, backupData, storage.VaultPermissions); err != nil {
-				return fmt.Errorf("failed to restore backup: %w", err)
-			}
-
-			// Remove incomplete temp file
-			_ = os.Remove(vaultTmpPath)
-
-			fmt.Fprintf(os.Stderr, "SUCCESS: Vault restored from backup. Your data is safe.\n")
-			fmt.Fprintf(os.Stderr, "You may continue using the vault normally.\n\n")
-		} else {
-			// No backup available - just remove temp file and warn
-			fmt.Fprintf(os.Stderr, "WARNING: No backup file found. Cleaning up temporary files.\n")
-			_ = os.Remove(vaultTmpPath)
-			fmt.Fprintf(os.Stderr, "If you experience issues, please report this immediately.\n\n")
-		}
+	if err := v.handleIncompleteMigration(); err != nil {
+		return err
 	}
 
-	// Convert to string for storage service (TODO: Phase 4 will update storage.go to accept []byte)
-	masterPasswordStr := string(masterPassword)
-
-	// Try to load vault
-	data, err := v.storageService.LoadVault(masterPasswordStr)
+	// Load + decrypt the vault (derives the key from the password — the
+	// expensive PBKDF2 step happens inside LoadVault).
+	data, err := v.storageService.LoadVault(string(masterPassword))
 	if err != nil {
 		// T068: Log unlock failure (FR-019)
 		v.LogAudit(security.EventVaultUnlock, security.OutcomeFailure, "")
 		return fmt.Errorf("failed to unlock vault: %w", err)
 	}
 
+	return v.finishUnlock(data, masterPassword)
+}
+
+// handleIncompleteMigration auto-recovers from an interrupted vault migration
+// (a leftover vault.tmp): restores from backup if present, otherwise cleans up
+// the temp file with a warning. No-op when no incomplete migration is detected.
+// T036e/T036g.
+func (v *VaultService) handleIncompleteMigration() error {
+	vaultTmpPath := v.vaultPath + storage.TempSuffix
+	vaultBackupPath := v.vaultPath + storage.BackupSuffix
+
+	if _, err := os.Stat(vaultTmpPath); err != nil {
+		return nil // no incomplete migration
+	}
+
+	// T036g: Incomplete migration detected - inform user with actionable message
+	fmt.Fprintf(os.Stderr, "\n*** MIGRATION FAILURE DETECTED ***\n")
+	fmt.Fprintf(os.Stderr, "An incomplete vault migration was found (power loss or system crash).\n")
+
+	if _, err := os.Stat(vaultBackupPath); err == nil {
+		// Backup exists - restore it
+		fmt.Fprintf(os.Stderr, "Attempting automatic recovery from backup...\n")
+
+		// Read backup
+		backupData, err := os.ReadFile(vaultBackupPath) // #nosec G304 -- Vault backup path validated by storage layer
+		if err != nil {
+			return fmt.Errorf("failed to read backup for rollback: %w", err)
+		}
+
+		// Restore to main vault path
+		if err := os.WriteFile(v.vaultPath, backupData, storage.VaultPermissions); err != nil {
+			return fmt.Errorf("failed to restore backup: %w", err)
+		}
+
+		// Remove incomplete temp file
+		_ = os.Remove(vaultTmpPath)
+
+		fmt.Fprintf(os.Stderr, "SUCCESS: Vault restored from backup. Your data is safe.\n")
+		fmt.Fprintf(os.Stderr, "You may continue using the vault normally.\n\n")
+	} else {
+		// No backup available - just remove temp file and warn
+		fmt.Fprintf(os.Stderr, "WARNING: No backup file found. Cleaning up temporary files.\n")
+		_ = os.Remove(vaultTmpPath)
+		fmt.Fprintf(os.Stderr, "If you experience issues, please report this immediately.\n\n")
+	}
+	return nil
+}
+
+// finishUnlock completes an unlock once the plaintext vault data is in hand,
+// independent of HOW it was decrypted (password path via Unlock, or prepared-key
+// path via UnlockWithPreparedKey). It sets in-memory state — including a copy of
+// masterPassword for later saves (NOT recoveryDEK; that distinction is why the
+// recovery-oriented UnlockWithKey can't be reused for keychain unlock) — restores
+// audit logging, synchronizes metadata, removes the post-migration backup, and
+// logs success.
+func (v *VaultService) finishUnlock(data []byte, masterPassword []byte) error {
 	// Unmarshal vault data
 	var vaultData VaultData
 	if err := json.Unmarshal(data, &vaultData); err != nil {


### PR DESCRIPTION
Completes **#103**. Tier 1 (#109) hid the pre-unlock probe latency behind the **password prompt**; this Tier 2 hides it for **keychain users** — the default/common case, who have no prompt to overlap — behind the **PBKDF2 key derivation** (600k iterations, ≈ tens-to-hundreds of ms; measured ~63ms on a fast desktop, more on a laptop). No staleness tradeoff.

> Note: the KDF is **PBKDF2-SHA256-600k**, not Argon2 (the issue text said "Argon2" — corrected here and in code comments).

## How it works

`Unlock` couples file-read + derive + decrypt, and a pull replaces the file, so the decrypt must run after the pull. But the expensive **derivation** only needs the password + the key params (salt/iterations/wrappedDEK) — *not* the ciphertext — so it can overlap the pull:

1. `PrepareUnlock()` reads the key params (cheap, pre-pull).
2. `SyncPull` runs in a goroutine while `DeriveDataKey` (PBKDF2) runs on the main goroutine — neither touches `vault.enc`.
3. Join, then `UnlockWithPreparedKey` decrypts the now-current file with the prepared key.

A single goroutine (the pull); the derive is on the main thread — same shape as Tier 1.

## The correctness crux: param-comparison, not decrypt-failure

If the pull brings a **re-keyed** vault, the prepared key is stale. The fallback gate compares the **current on-disk key params against the captured ones** — mismatch ⇒ discard the prepared key, fall back to a full password unlock.

This is deliberately *not* "try the key, fall back on decrypt failure". For a **v2** vault a remote **password-only change preserves the DEK**, so a stale prepared DEK would still decrypt — and we'd unlock with a stale `masterPassword` (reads work, **saves break**). Param-comparison makes Tier 2 behave **identically to a sequential unlock** on every re-key: a stale keychain password fails *cleanly at unlock*. (A decrypt failure is kept as a belt-and-suspenders second fallback.)

## Staged for safety

1. `refactor(vault)`: extract `handleIncompleteMigration` + `finishUnlock` from `Unlock` — **pure no-behavior-change**, verified green by the existing Unlock tests, so the new path reuses proven state-setup (retains `masterPassword`, not `recoveryDEK`).
2. `feat(vault)`: storage `ReadKeyParams`/`DeriveDataKey`/`Equal` + vault `PrepareUnlock`/`UnlockWithPreparedKey`.
3. `perf(sync)`: wire the cmd keychain branch.

## Tests (all `-race`)

- vault: happy path (params match → prepared key used, save works, not a recovery unlock); **re-key → fallback to current password succeeds**; **stale password after re-key → fails cleanly, vault stays locked**.
- cmd: drives the keychain overlap end-to-end against a real sync-enabled, initialized vault (no keychain backend needed) — correct unlock + working save.
- Full unit + integration green; `cmd`/`vault`/`storage` pass `go test -race`; `golangci-lint v2.5` clean.

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)