### PR TITLE
chore(org): complete arimxyer → reyamira repo reference sweep

### DIFF
--- a/.doc-manager/dependencies.json
+++ b/.doc-manager/dependencies.json
@@ -4151,7 +4151,7 @@
     "docsite/static/images/tui-demo.png": [
       "README.md"
     ],
-    "https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version": [
+    "https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version": [
       "01-getting-started/quick-install.md",
       "01-getting-started/quick-start.md",
       "02-guides/recovery-phrase.md",
@@ -4169,7 +4169,7 @@
       "06-development/scoop.md",
       "_index.md"
     ],
-    "https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated": [
+    "https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated": [
       "01-getting-started/quick-install.md",
       "01-getting-started/quick-start.md",
       "02-guides/recovery-phrase.md",

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://arimxyer.github.io/pass-cli/
+    url: https://reyamira.github.io/pass-cli/
     about: Check the documentation for usage guides and examples

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -8,8 +8,8 @@ body:
         Have a question? We're happy to help!
 
         **Note:** For general usage questions, also check:
-        - [README](https://github.com/arimxyer/pass-cli#readme)
-        - [Documentation](https://arimxyer.github.io/pass-cli/)
+        - [README](https://github.com/reyamira/pass-cli#readme)
+        - [Documentation](https://reyamira.github.io/pass-cli/)
 
   - type: textarea
     id: question

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -119,7 +119,7 @@ jobs:
           fi
 
           # Check for absolute GitHub links to own repo (should be relative)
-          if grep -r "https://github.com/arimxyer/pass-cli/blob/main/docs" docs/ --include="*.md"; then
+          if grep -r "https://github.com/reyamira/pass-cli/blob/main/docs" docs/ --include="*.md"; then
             echo "⚠️ Warning: Found absolute GitHub links (use relative paths instead)"
           fi
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,7 +62,7 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
     # Files to include in archive (essential docs only)
-    # Full documentation available at https://arimxyer.github.io/pass-cli/
+    # Full documentation available at https://reyamira.github.io/pass-cli/
     files:
       - LICENSE*
       - README*
@@ -104,7 +104,7 @@ changelog:
 
 release:
   github:
-    owner: arimxyer
+    owner: reyamira
     name: pass-cli
 
   # Release name format
@@ -129,12 +129,12 @@ release:
 
     #### Homebrew (macOS/Linux)
     ```bash
-    brew install arimxyer/tap/pass-cli
+    brew install reyamira/tap/pass-cli
     ```
 
     #### Scoop (Windows)
     ```powershell
-    scoop bucket add arimxyer https://github.com/arimxyer/scoop-bucket
+    scoop bucket add reyamira https://github.com/reyamira/scoop-bucket
     scoop install pass-cli
     ```
 
@@ -150,7 +150,7 @@ release:
     ```
 
     ### Full Changelog
-    See the full changelog at https://github.com/arimxyer/pass-cli/blob/main/CHANGELOG.md
+    See the full changelog at https://github.com/reyamira/pass-cli/blob/main/CHANGELOG.md
 
 # Universal Binaries for macOS (combines amd64 and arm64)
 universal_binaries:
@@ -260,7 +260,7 @@ brews:
 
     # Tap repository (GoReleaser will auto-create/update the formula)
     repository:
-      owner: arimxyer
+      owner: reyamira
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
 
@@ -268,7 +268,7 @@ brews:
     directory: Formula
 
     # Metadata
-    homepage: https://github.com/arimxyer/pass-cli
+    homepage: https://github.com/reyamira/pass-cli
     description: "Secure, cross-platform CLI password and API key manager for developers"
     license: MIT
 
@@ -297,7 +297,7 @@ brews:
         • Usage tracking and audit logging
 
       Vault location: ~/.pass-cli/vault.enc
-      Complete guide: https://github.com/arimxyer/pass-cli/blob/main/docs/GETTING_STARTED.md
+      Complete guide: https://github.com/reyamira/pass-cli/blob/main/docs/GETTING_STARTED.md
 
 # Scoop bucket (automated manifest creation and updates)
 scoops:
@@ -305,7 +305,7 @@ scoops:
 
     # Bucket repository (GoReleaser will auto-create/update the manifest)
     repository:
-      owner: arimxyer
+      owner: reyamira
       name: scoop-bucket
       token: "{{ .Env.SCOOP_BUCKET_TOKEN }}"
 
@@ -313,7 +313,7 @@ scoops:
     directory: bucket
 
     # Metadata
-    homepage: https://github.com/arimxyer/pass-cli
+    homepage: https://github.com/reyamira/pass-cli
     description: "Secure, cross-platform CLI password and API key manager for developers"
     license: MIT
 
@@ -321,4 +321,4 @@ scoops:
     post_install:
       - "Write-Host 'Pass-CLI installed! First-time: Run `pass-cli` for guided setup.' -ForegroundColor Green"
       - "Write-Host 'TUI: pass-cli | Health check: pass-cli doctor | Enable keychain: pass-cli keychain enable' -ForegroundColor Cyan"
-      - "Write-Host 'Guide: https://github.com/arimxyer/pass-cli/blob/main/docs/GETTING_STARTED.md' -ForegroundColor Yellow"
+      - "Write-Host 'Guide: https://github.com/reyamira/pass-cli/blob/main/docs/GETTING_STARTED.md' -ForegroundColor Yellow"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **`exec` command — inject credentials as environment variables** (#98) — `pass-cli exec` runs a child command with stored credentials passed only through its environment, so the secret never touches a file, the clipboard, or shell history. Supports an explicit, repeatable `--set ENV_NAME=service[:field]` mapping and a convenience form (`pass-cli exec <service> -- <cmd>`) that derives the env name from the service (uppercased, non-alphanumeric → `_`, e.g. `openai-api` → `OPENAI_API`). The `-f/--field` flag selects the field for all mappings (default `password`); a per-mapping `:field` suffix overrides it, allowing two fields of one entry to be injected as separate variables. Everything after `--` is the child argv, and the child's exit code is propagated unchanged. `exec` is read-only: it records no usage and triggers no sync push, making it safe on a hot path.
+- **`--offline` global flag** (#104) — run a command fully local: skips both the pre-unlock remote pull and the post-command push (offline changes sync on the next online run).
 
 ### Changed
 - **`list` is now safe-by-default** (#95, #97) — the default table hides the Username column, because the "username" field can hold sensitive values (card, account, or routing numbers stored as a username). New `--show-usernames` re-adds the column, and new `-q/--quiet` is a shorthand for `--format simple` (bare service names, one per line) that takes precedence over `--format`. `--format json` is unchanged and still emits full metadata including usernames as an explicit, structured opt-in.
 - **Sync: content-hash change detection** (#102) — push change-detection now uses a name-encoded zero-byte marker (`vault.enc.<sha256>.synchash`) written next to the vault on each push, replacing the old modtime+size heuristic; older vaults without a marker fall back to the previous behavior.
 - **Sync: lower unlock latency by overlapping the pull** (#103) — the pre-unlock remote pull now runs concurrently with the master-password prompt (Tier 1, #109) and with PBKDF2-SHA256 key derivation on keychain unlock (Tier 2, #110). Internal only; no flag or UX change.
-- **Sync: cut sync-related startup latency** (#104) — removed the dead `--hash` flag and the "Syncing… done" feedback line. The global `--offline` flag is unaffected and still works.
+- **Sync: cut sync-related startup latency** (#104) — dropped the dead `rclone lsjson --hash` flag (no decision used the remote hash; it only added backend hashing cost) and added a transient progress indicator on stderr during the pre-unlock remote probe.
+- **Org transfer to `reyamira`** (#112) — the repository and its package sources (Homebrew tap, Scoop bucket, GitHub Pages, badges) moved from `arimxyer` to `reyamira`. Install commands now reference `reyamira/...` (old URLs redirect). The Go module path (`github.com/arimxyer/pass-cli`) is intentionally unchanged.
 
 ### Fixed
 - **Test: resolve `captureStdout` redeclaration across `cmd` test files** (#99)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -478,4 +478,4 @@ This changelog follows these principles:
 - **Fixed** for any bug fixes
 - **Security** for vulnerability fixes
 
-For detailed commit-level changes, see [GitHub Releases](https://github.com/arimxyer/pass-cli/releases).
+For detailed commit-level changes, see [GitHub Releases](https://github.com/reyamira/pass-cli/releases).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Pass-CLI
 Thank you for your interest in contributing to Pass-CLI! This document provides guidelines for contributing to the project.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?label=Last%20Updated)
 
 
 ## Documentation Governance

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 <p align="center">
   <strong>A secure, cross-platform, always-free, and open-source alternative to 1password, bitwarden, etc., Password and API key manager for folks who live in the command line. (CLI + TUI) </strong>
 <p align="center">
-  <img src="https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version" alt="Version">
-  <img src="https://img.shields.io/github/last-commit/arimxyer/pass-cli?label=Last%20Updated" alt="Last Updated">
+  <img src="https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version" alt="Version">
+  <img src="https://img.shields.io/github/last-commit/reyamira/pass-cli?label=Last%20Updated" alt="Last Updated">
 </p>
 
 Pass-CLI is a fast, secure password and API key manager that stores credentials locally with AES-256-GCM encryption. Built for developers who need quick, script-friendly access to credentials without cloud dependencies.
 
-📚 **[View Full Documentation](https://arimxyer.github.io/pass-cli/)** | [Getting Started](docs/01-getting-started/quick-start.md) | [Installation](docs/01-getting-started/quick-install.md) | [Usage Guide](docs/03-reference/command-reference.md)
+📚 **[View Full Documentation](https://reyamira.github.io/pass-cli/)** | [Getting Started](docs/01-getting-started/quick-start.md) | [Installation](docs/01-getting-started/quick-install.md) | [Usage Guide](docs/03-reference/command-reference.md)
 
 ## Key Features
 
@@ -36,13 +36,13 @@ Pass-CLI is a fast, secure password and API key manager that stores credentials 
 
 **macOS / Linux (Homebrew)**:
 ```bash
-brew tap arimxyer/homebrew-tap
+brew tap reyamira/homebrew-tap
 brew install pass-cli
 ```
 
 **Windows (Scoop)**:
 ```powershell
-scoop bucket add arimxyer https://github.com/arimxyer/scoop-bucket
+scoop bucket add reyamira https://github.com/reyamira/scoop-bucket
 scoop install pass-cli
 ```
 
@@ -222,7 +222,7 @@ For complete security details, best practices, and migration guides, see [docs/0
 
 ```bash
 # Clone and build
-git clone https://github.com/arimxyer/pass-cli.git
+git clone https://github.com/reyamira/pass-cli.git
 cd pass-cli
 go build -o pass-cli .
 
@@ -268,7 +268,7 @@ For more questions and troubleshooting, see [docs/04-troubleshooting/faq.md](doc
 
 ## Roadmap
 
-Have a feature request? Open an issue on [GitHub](https://github.com/arimxyer/pass-cli/issues).
+Have a feature request? Open an issue on [GitHub](https://github.com/reyamira/pass-cli/issues).
 
 ## Contributing
 
@@ -280,9 +280,9 @@ This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE
 
 ## Links
 
-- **Releases**: [GitHub Releases](https://github.com/arimxyer/pass-cli/releases)
-- **Issues**: [GitHub Issues](https://github.com/arimxyer/pass-cli/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/arimxyer/pass-cli/discussions)
+- **Releases**: [GitHub Releases](https://github.com/reyamira/pass-cli/releases)
+- **Issues**: [GitHub Issues](https://github.com/reyamira/pass-cli/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/reyamira/pass-cli/discussions)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ We release security updates for the following versions:
 
 Instead, please report security vulnerabilities through GitHub's private vulnerability reporting:
 
-1. Go to the [Security tab](https://github.com/arimxyer/pass-cli/security)
+1. Go to the [Security tab](https://github.com/reyamira/pass-cli/security)
 2. Click "Report a vulnerability"
 3. Fill out the advisory form with the details below
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -71,7 +71,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// Build check options
 	opts := health.CheckOptions{
 		CurrentVersion:  version,
-		GitHubRepo:      "arimxyer/pass-cli",
+		GitHubRepo:      "reyamira/pass-cli",
 		VaultPath:       vaultPath,
 		VaultPathSource: vaultSource,
 		VaultDir:        filepath.Dir(vaultPath),

--- a/cmd/keychain_status.go
+++ b/cmd/keychain_status.go
@@ -119,12 +119,12 @@ func runKeychainStatus(cmd *cobra.Command, args []string) error {
 		} else if meta != nil && !meta.KeychainEnabled {
 			fmt.Printf("✓ Vault Configuration:    Keychain not enabled\n\n")
 			fmt.Println("System keychain is not accessible. You will be prompted for password on each command.")
-			fmt.Println("See documentation for keychain setup: https://github.com/arimxyer/pass-cli/blob/main/docs/GETTING_STARTED.md#keychain-integration")
+			fmt.Println("See documentation for keychain setup: https://github.com/reyamira/pass-cli/blob/main/docs/GETTING_STARTED.md#keychain-integration")
 		} else {
 			// No metadata - legacy vault
 			fmt.Println()
 			fmt.Println("System keychain is not accessible. You will be prompted for password on each command.")
-			fmt.Println("See documentation for keychain setup: https://github.com/arimxyer/pass-cli/blob/main/docs/GETTING_STARTED.md#keychain-integration")
+			fmt.Println("See documentation for keychain setup: https://github.com/reyamira/pass-cli/blob/main/docs/GETTING_STARTED.md#keychain-integration")
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,7 @@ Examples:
   # List all credentials
   pass-cli list
 
-For more information, visit: https://github.com/arimxyer/pass-cli`,
+For more information, visit: https://github.com/reyamira/pass-cli`,
 		PersistentPreRunE: checkFirstRun,
 		Run:               runRootCommand,
 	}
@@ -67,7 +67,7 @@ func Execute() {
 
 func init() {
 	// NOTE: Config loading moved to PersistentPreRunE to ensure --config flag is parsed first
-	// See issue #65: https://github.com/arimxyer/pass-cli/issues/65
+	// See issue #65: https://github.com/reyamira/pass-cli/issues/65
 
 	// T037: Custom flag error handler for migration guidance
 	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
@@ -81,7 +81,7 @@ Instead, configure your vault location in the config file:
   3. Run your command without the --vault flag
 
 For more details, see the migration guide:
-  https://github.com/arimxyer/pass-cli/blob/main/docs/MIGRATION.md
+  https://github.com/reyamira/pass-cli/blob/main/docs/MIGRATION.md
 
 Original error: %w`, os.Getenv("HOME"), err)
 		}

--- a/docs/01-getting-started/manual-install.md
+++ b/docs/01-getting-started/manual-install.md
@@ -10,7 +10,7 @@ Manual installation gives you direct control over the binary location and versio
 
 1. **Visit the Releases Page**
 
-   Go to [GitHub Releases](https://github.com/arimxyer/pass-cli/releases/latest)
+   Go to [GitHub Releases](https://github.com/reyamira/pass-cli/releases/latest)
 
 2. **Choose Your Platform**
 
@@ -39,7 +39,7 @@ Verifying checksums ensures the downloaded file hasn't been tampered with.
 # Download your platform's archive and checksums.txt
 # Go to GitHub Releases and download your platform's archive
 # Example for Linux amd64:
-# 1. Visit: https://github.com/arimxyer/pass-cli/releases/latest
+# 1. Visit: https://github.com/reyamira/pass-cli/releases/latest
 # 2. Download: pass-cli_VERSION_linux_amd64.tar.gz
 # 3. Download: checksums.txt
 
@@ -71,7 +71,7 @@ fi
 #### Windows (PowerShell)
 
 ```powershell
-# After downloading from https://github.com/arimxyer/pass-cli/releases/latest
+# After downloading from https://github.com/reyamira/pass-cli/releases/latest
 # Replace with your downloaded filename
 $file = "pass-cli_X.Y.Z_windows_amd64.zip"
 
@@ -188,7 +188,7 @@ git --version
 
 ```bash
 # Clone the repository
-git clone https://github.com/arimxyer/pass-cli.git
+git clone https://github.com/reyamira/pass-cli.git
 cd pass-cli
 
 # Checkout specific version (optional)

--- a/docs/01-getting-started/quick-install.md
+++ b/docs/01-getting-started/quick-install.md
@@ -5,7 +5,7 @@ toc: true
 ---
 Fast installation using package managers for Pass-CLI across all supported platforms.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 ## Quick Install
 
@@ -13,7 +13,7 @@ Fast installation using package managers for Pass-CLI across all supported platf
 
 ```bash
 # Using Homebrew
-brew tap arimxyer/homebrew-tap
+brew tap reyamira/homebrew-tap
 brew install pass-cli
 ```
 
@@ -21,7 +21,7 @@ brew install pass-cli
 
 ```powershell
 # Using Scoop
-scoop bucket add pass-cli https://github.com/arimxyer/scoop-bucket
+scoop bucket add pass-cli https://github.com/reyamira/scoop-bucket
 scoop install pass-cli
 ```
 
@@ -42,7 +42,7 @@ Homebrew is the recommended installation method for macOS and Linux.
 
 ```bash
 # Add the Pass-CLI tap
-brew tap arimxyer/homebrew-tap
+brew tap reyamira/homebrew-tap
 
 # Install Pass-CLI
 brew install pass-cli
@@ -85,7 +85,7 @@ Scoop is the recommended installation method for Windows.
 
 ```powershell
 # Add the Pass-CLI bucket
-scoop bucket add pass-cli https://github.com/arimxyer/scoop-bucket
+scoop bucket add pass-cli https://github.com/reyamira/scoop-bucket
 
 # Install Pass-CLI
 scoop install pass-cli

--- a/docs/01-getting-started/quick-start.md
+++ b/docs/01-getting-started/quick-start.md
@@ -6,7 +6,7 @@ toc: true
 
 This 5-minute guide will walk you through initializing your vault and storing your first credential.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 ## Installation
 

--- a/docs/01-getting-started/uninstall.md
+++ b/docs/01-getting-started/uninstall.md
@@ -15,7 +15,7 @@ Complete instructions for removing pass-cli from your system.
 brew uninstall pass-cli
 
 # Remove tap (optional)
-brew untap arimxyer/homebrew-tap
+brew untap reyamira/homebrew-tap
 
 # Remove vault (if desired)
 rm -rf ~/.pass-cli
@@ -110,14 +110,14 @@ history -c
 If you encounter issues not covered here:
 
 1. Check the [Troubleshooting Guide](../04-troubleshooting/_index)
-2. Review [GitHub Issues](https://github.com/arimxyer/pass-cli/issues)
-3. Ask in [GitHub Discussions](https://github.com/arimxyer/pass-cli/discussions)
-4. File a [new issue](https://github.com/arimxyer/pass-cli/issues/new)
+2. Review [GitHub Issues](https://github.com/reyamira/pass-cli/issues)
+3. Ask in [GitHub Discussions](https://github.com/reyamira/pass-cli/discussions)
+4. File a [new issue](https://github.com/reyamira/pass-cli/issues/new)
 
 ## Next Steps
 
 After uninstalling, you might want to:
 
 - Review the [Security Architecture](../03-reference/security-architecture)
-- Check [pass-cli Documentation](https://arimxyer.github.io/pass-cli/) for other topics
+- Check [pass-cli Documentation](https://reyamira.github.io/pass-cli/) for other topics
 

--- a/docs/02-guides/recovery-phrase.md
+++ b/docs/02-guides/recovery-phrase.md
@@ -6,7 +6,7 @@ toc: true
 
 Complete guide to using BIP39 recovery phrases to recover vault access if you forget your master password.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 ## Overview
 

--- a/docs/02-guides/scripting-guide.md
+++ b/docs/02-guides/scripting-guide.md
@@ -290,7 +290,7 @@ $env:PASS_CLI_VERBOSE = "1"
 pass-cli get github
 ```
 
-**Note**: To use a custom vault location, configure `vault_path` in the config file (`~/.pass-cli/config.yml`) instead of using environment variables. See [Configuration](#configuration) section.
+**Note**: To use a custom vault location, configure `vault_path` in the config file (`~/.pass-cli/config.yml`) instead of using environment variables. See the [Configuration reference](../03-reference/configuration.md).
 
 ## Best Practices
 

--- a/docs/02-guides/sync-guide.md
+++ b/docs/02-guides/sync-guide.md
@@ -322,10 +322,10 @@ Remote path: gdrive:.pass-cli
 
 ```bash
 # macOS
-brew tap arimxyer/homebrew-tap && brew install pass-cli rclone
+brew tap reyamira/homebrew-tap && brew install pass-cli rclone
 
 # Windows
-scoop bucket add arimxyer https://github.com/arimxyer/scoop-bucket
+scoop bucket add reyamira https://github.com/reyamira/scoop-bucket
 scoop install pass-cli rclone
 
 # Linux

--- a/docs/03-reference/command-reference.md
+++ b/docs/03-reference/command-reference.md
@@ -5,7 +5,7 @@ toc: true
 ---
 Complete reference for all pass-cli commands and their options.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 ## Global Options
 
@@ -2168,7 +2168,7 @@ See [Quick Start Guide](../01-getting-started/quick-start) for complete first-ru
 ## Getting Help
 
 - Run any command with `--help` flag
-- See [pass-cli Documentation](https://arimxyer.github.io/pass-cli/) for overview
+- See [pass-cli Documentation](https://reyamira.github.io/pass-cli/) for overview
 - Check [Troubleshooting](../04-troubleshooting/_index) for common issues
-- Visit [GitHub Issues](https://github.com/arimxyer/pass-cli/issues)
+- Visit [GitHub Issues](https://github.com/reyamira/pass-cli/issues)
 

--- a/docs/03-reference/known-limitations.md
+++ b/docs/03-reference/known-limitations.md
@@ -5,7 +5,7 @@ toc: true
 ---
 Documentation of known technical limitations in Pass-CLI and their security implications.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 
 ## TUI Password Input Memory Handling

--- a/docs/03-reference/migration.md
+++ b/docs/03-reference/migration.md
@@ -5,7 +5,7 @@ toc: true
 ---
 Guide for upgrading Pass-CLI vaults and adapting to security hardening changes introduced in v0.3.0.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 
 ## Overview
@@ -739,5 +739,5 @@ Time includes manual re-entry of credentials. Future in-place migration will be 
 ## Support
 
 - **Documentation**: [Security Architecture](security-architecture), [Command Reference](command-reference)
-- **Issues**: [GitHub Issues](https://github.com/arimxyer/pass-cli/issues)
+- **Issues**: [GitHub Issues](https://github.com/reyamira/pass-cli/issues)
 

--- a/docs/03-reference/security-architecture.md
+++ b/docs/03-reference/security-architecture.md
@@ -5,7 +5,7 @@ toc: true
 ---
 Comprehensive security architecture, cryptographic implementation, threat model, and security guarantees for Pass-CLI.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 ## Security Overview
 

--- a/docs/04-troubleshooting/installation.md
+++ b/docs/04-troubleshooting/installation.md
@@ -5,7 +5,7 @@ toc: true
 ---
 Solutions for installation and initialization problems.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 ## Installation Issues
 
@@ -83,8 +83,8 @@ brew update
 brew doctor
 
 # Remove and re-add tap
-brew untap arimxyer/pass-cli
-brew tap arimxyer/pass-cli
+brew untap reyamira/pass-cli
+brew tap reyamira/pass-cli
 
 # Try verbose installation
 brew install --verbose pass-cli
@@ -109,7 +109,7 @@ scoop status
 
 # Remove and re-add bucket
 scoop bucket rm pass-cli
-scoop bucket add pass-cli https://github.com/arimxyer/scoop-bucket
+scoop bucket add pass-cli https://github.com/reyamira/scoop-bucket
 
 # Clear cache and retry
 scoop cache rm pass-cli
@@ -142,7 +142,7 @@ xattr -d com.apple.quarantine /usr/local/bin/pass-cli
 
 **Option 3: Build from source** (trusted)
 ```bash
-git clone https://github.com/arimxyer/pass-cli
+git clone https://github.com/reyamira/pass-cli
 cd pass-cli
 go build -o pass-cli .
 sudo mv pass-cli /usr/local/bin/

--- a/docs/05-operations/health-checks.md
+++ b/docs/05-operations/health-checks.md
@@ -5,7 +5,7 @@ toc: true
 ---
 The `pass-cli doctor` command provides comprehensive health checks for your pass-cli installation. Use it to diagnose issues, verify your setup, and ensure everything is working correctly.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 .
 
 ## Overview
@@ -144,7 +144,7 @@ esac
 **Symptom**:
 ```text
 ⚠ Version: Update available: v1.2.3 → v1.2.4
-  Recommendation: Update to latest version: https://github.com/arimxyer/pass-cli/releases/tag/v1.2.4
+  Recommendation: Update to latest version: https://github.com/reyamira/pass-cli/releases/tag/v1.2.4
 ```
 
 **Solution**: Update pass-cli to the latest version using your package manager or download from GitHub.

--- a/docs/05-operations/security-operations.md
+++ b/docs/05-operations/security-operations.md
@@ -244,7 +244,7 @@ Pass-CLI has not yet undergone external security audit. We welcome security rese
 **DO NOT** file public issues for security vulnerabilities.
 
 Instead, use GitHub's private security advisory feature to report vulnerabilities:
-- Visit: https://github.com/arimxyer/pass-cli/security/advisories/new
+- Visit: https://github.com/reyamira/pass-cli/security/advisories/new
 - Include: Detailed description, reproduction steps, impact assessment
 - Disclosure: Coordinated disclosure after fix
 
@@ -258,7 +258,7 @@ Security updates are released as:
 Check for updates:
 ```bash
 pass-cli version
-# Compare with latest: https://github.com/arimxyer/pass-cli/releases
+# Compare with latest: https://github.com/reyamira/pass-cli/releases
 ```
 
 ## Cryptographic Algorithm Details

--- a/docs/06-development/branch-workflow.md
+++ b/docs/06-development/branch-workflow.md
@@ -5,7 +5,7 @@ toc: true
 ---
 This document describes the branching strategy and workflow for pass-cli development.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 
 ## Branch Structure
@@ -24,7 +24,7 @@ This document describes the branching strategy and workflow for pass-cli develop
 
 ```bash
 # Clone repo (if new)
-git clone https://github.com/arimxyer/pass-cli.git
+git clone https://github.com/reyamira/pass-cli.git
 cd pass-cli
 
 # Make sure you're up to date
@@ -50,7 +50,7 @@ git commit -m "feat: add new feature"
 git push origin feat/my-feature-name
 
 # Create PR via GitHub
-# Go to: https://github.com/arimxyer/pass-cli/compare/main...feat/my-feature-name
+# Go to: https://github.com/reyamira/pass-cli/compare/main...feat/my-feature-name
 # CI runs automatically on your PR
 ```
 
@@ -313,8 +313,8 @@ git push origin feat/my-feature
 
 ## References
 
-- GitHub Actions: https://github.com/arimxyer/pass-cli/actions
-- Branch Settings: https://github.com/arimxyer/pass-cli/settings/rules
+- GitHub Actions: https://github.com/reyamira/pass-cli/actions
+- Branch Settings: https://github.com/reyamira/pass-cli/settings/rules
 - Release Workflow: `.github/workflows/release.yml`
 - CI Workflow: `.github/workflows/ci.yml`
-- Pull Requests: https://github.com/arimxyer/pass-cli/pulls
+- Pull Requests: https://github.com/reyamira/pass-cli/pulls

--- a/docs/06-development/ci-cd.md
+++ b/docs/06-development/ci-cd.md
@@ -5,7 +5,7 @@ toc: true
 ---
 This document describes the automated CI/CD pipeline for Pass-CLI.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 
 ## Workflows
@@ -294,10 +294,10 @@ goreleaser release --snapshot --clean --skip=publish
 Add to README.md:
 
 ```markdown
-[![CI](https://github.com/arimxyer/pass-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/arimxyer/pass-cli/actions/workflows/ci.yml)
-[![Release](https://github.com/arimxyer/pass-cli/actions/workflows/release.yml/badge.svg)](https://github.com/arimxyer/pass-cli/actions/workflows/release.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/arimxyer/pass-cli)](https://goreportcard.com/report/github.com/arimxyer/pass-cli)
-[![codecov](https://codecov.io/gh/arimxyer/pass-cli/branch/main/graph/badge.svg)](https://codecov.io/gh/arimxyer/pass-cli)
+[![CI](https://github.com/reyamira/pass-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/reyamira/pass-cli/actions/workflows/ci.yml)
+[![Release](https://github.com/reyamira/pass-cli/actions/workflows/release.yml/badge.svg)](https://github.com/reyamira/pass-cli/actions/workflows/release.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/reyamira/pass-cli)](https://goreportcard.com/report/github.com/reyamira/pass-cli)
+[![codecov](https://codecov.io/gh/reyamira/pass-cli/branch/main/graph/badge.svg)](https://codecov.io/gh/reyamira/pass-cli)
 ```
 
 ## Security

--- a/docs/06-development/contributing.md
+++ b/docs/06-development/contributing.md
@@ -5,7 +5,7 @@ toc: true
 ---
 This guide covers the development workflow for Pass-CLI contributors.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 
 ## Prerequisites
@@ -26,7 +26,7 @@ This guide covers the development workflow for Pass-CLI contributors.
 
 ```bash
 # Clone the repository
-git clone https://github.com/arimxyer/pass-cli.git
+git clone https://github.com/reyamira/pass-cli.git
 cd pass-cli
 
 # Install dependencies
@@ -463,12 +463,12 @@ Contributions are welcome! Please:
 4. Run all tests and quality checks (see "Before Committing" section)
 5. Submit a pull request
 
-For questions or discussions, visit [GitHub Discussions](https://github.com/arimxyer/pass-cli/discussions).
+For questions or discussions, visit [GitHub Discussions](https://github.com/reyamira/pass-cli/discussions).
 
 ## Getting Help
 
-- **Issues**: [GitHub Issues](https://github.com/arimxyer/pass-cli/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/arimxyer/pass-cli/discussions)
+- **Issues**: [GitHub Issues](https://github.com/reyamira/pass-cli/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/reyamira/pass-cli/discussions)
 - **Documentation**: [docs/](../_index.md)
 
 ## Resources

--- a/docs/06-development/homebrew.md
+++ b/docs/06-development/homebrew.md
@@ -5,7 +5,7 @@ toc: true
 ---
 This document explains how to use, test, and submit the Homebrew formula for Pass-CLI.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 ## Overview
 
@@ -22,7 +22,7 @@ The Homebrew formula enables easy installation of Pass-CLI on macOS and Linux sy
 
 ```bash
 # Add the tap
-brew tap arimxyer/homebrew-tap
+brew tap reyamira/homebrew-tap
 
 # Install Pass-CLI
 brew install pass-cli
@@ -49,7 +49,7 @@ A Homebrew tap is a GitHub repository that contains Homebrew formulae.
 
 ```bash
 # Clone your new repository
-git clone https://github.com/arimxyer/homebrew-tap.git
+git clone https://github.com/reyamira/homebrew-tap.git
 cd homebrew-tap
 
 # Create Formula directory
@@ -70,7 +70,7 @@ After creating a release, you need to update the SHA256 checksums in the formula
 
 ```bash
 # Download each release artifact and calculate its checksum
-curl -L "https://github.com/arimxyer/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_darwin_amd64.tar.gz" | sha256sum
+curl -L "https://github.com/reyamira/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_darwin_amd64.tar.gz" | sha256sum
 
 # Repeat for each platform:
 # - darwin_amd64
@@ -90,7 +90,7 @@ curl -L "https://github.com/arimxyer/pass-cli/releases/download/v0.0.1/pass-cli_
 brew install --build-from-source homebrew/pass-cli.rb
 
 # Or use brew install with the tap
-brew install --debug --verbose arimxyer/homebrew-tap/pass-cli
+brew install --debug --verbose reyamira/homebrew-tap/pass-cli
 
 # Test the installation
 pass-cli version
@@ -195,7 +195,7 @@ When releasing a new version:
 
 2. **Update URLs**
    ```ruby
-   url "https://github.com/arimxyer/pass-cli/releases/download/v1.1.0/..."
+   url "https://github.com/reyamira/pass-cli/releases/download/v1.1.0/..."
    ```
 
 3. **Update SHA256 Checksums**
@@ -226,7 +226,7 @@ Consider adding automation to update checksums:
 # Example script to calculate checksums
 #!/bin/bash
 VERSION="0.0.1"
-BASE_URL="https://github.com/arimxyer/pass-cli/releases/download/v${VERSION}"
+BASE_URL="https://github.com/reyamira/pass-cli/releases/download/v${VERSION}"
 
 for os in darwin linux; do
   for arch in amd64 arm64; do

--- a/docs/06-development/release.md
+++ b/docs/06-development/release.md
@@ -5,7 +5,7 @@ toc: true
 ---
 This document describes the release process for Pass-CLI using GoReleaser.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 
 ## Prerequisites

--- a/docs/06-development/scoop.md
+++ b/docs/06-development/scoop.md
@@ -5,7 +5,7 @@ toc: true
 ---
 This document explains how to use, test, and submit the Scoop manifest for Pass-CLI on Windows.
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 
 ## Overview
@@ -23,7 +23,7 @@ The Scoop manifest enables easy installation of Pass-CLI on Windows systems thro
 
 ```powershell
 # Add the bucket
-scoop bucket add pass-cli https://github.com/arimxyer/scoop-bucket
+scoop bucket add pass-cli https://github.com/reyamira/scoop-bucket
 
 # Install Pass-CLI
 scoop install pass-cli
@@ -55,7 +55,7 @@ A Scoop bucket is a GitHub repository that contains Scoop manifests.
 
 ```powershell
 # Clone your new repository
-git clone https://github.com/arimxyer/scoop-bucket.git
+git clone https://github.com/reyamira/scoop-bucket.git
 cd scoop-bucket
 
 # Create bucket directory structure
@@ -76,7 +76,7 @@ After creating a release, you need to update the SHA256 hashes in the manifest:
 
 ```powershell
 # Download each release artifact and calculate its hash
-$url = "https://github.com/arimxyer/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_windows_amd64.zip"
+$url = "https://github.com/reyamira/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_windows_amd64.zip"
 $hash = (Get-FileHash (Invoke-WebRequest $url -OutFile temp.zip -PassThru).FullName -Algorithm SHA256).Hash
 
 # Repeat for each architecture:
@@ -89,7 +89,7 @@ $hash = (Get-FileHash (Invoke-WebRequest $url -OutFile temp.zip -PassThru).FullN
 Alternatively, use Scoop's built-in hash tool:
 
 ```powershell
-scoop hash https://github.com/arimxyer/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_windows_amd64.zip
+scoop hash https://github.com/reyamira/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_windows_amd64.zip
 ```
 
 ## Testing the Manifest
@@ -101,7 +101,7 @@ scoop hash https://github.com/arimxyer/pass-cli/releases/download/v0.0.1/pass-cl
 scoop install .\scoop\pass-cli.json
 
 # Or test from the bucket
-scoop bucket add pass-cli https://github.com/arimxyer/scoop-bucket
+scoop bucket add pass-cli https://github.com/reyamira/scoop-bucket
 scoop install pass-cli
 
 # Test the installation
@@ -175,7 +175,7 @@ Test on all supported Windows architectures:
 ```json
 {
   "checkver": {
-    "github": "https://github.com/arimxyer/pass-cli"
+    "github": "https://github.com/reyamira/pass-cli"
   },
   "autoupdate": {
     "architecture": {
@@ -323,12 +323,12 @@ When releasing a new version:
 
 2. **Update URLs**
    ```json
-   "url": "https://github.com/arimxyer/pass-cli/releases/download/v1.1.0/..."
+   "url": "https://github.com/reyamira/pass-cli/releases/download/v1.1.0/..."
    ```
 
 3. **Update Hashes**
    ```powershell
-   scoop hash https://github.com/arimxyer/pass-cli/releases/download/v1.1.0/pass-cli_1.1.0_windows_amd64.zip
+   scoop hash https://github.com/reyamira/pass-cli/releases/download/v1.1.0/pass-cli_1.1.0_windows_amd64.zip
    ```
 
 4. **Test and Submit**
@@ -365,7 +365,7 @@ param(
     [string]$Version
 )
 
-$baseUrl = "https://github.com/arimxyer/pass-cli/releases/download/v$Version"
+$baseUrl = "https://github.com/reyamira/pass-cli/releases/download/v$Version"
 $manifest = Get-Content scoop\pass-cli.json | ConvertFrom-Json
 
 # Update version
@@ -419,7 +419,7 @@ Usage:
 
 ```powershell
 # Recalculate the hash
-scoop hash https://github.com/arimxyer/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_windows_amd64.zip
+scoop hash https://github.com/reyamira/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_windows_amd64.zip
 
 # Or manually
 $hash = (Get-FileHash .\pass-cli_0.0.1_windows_amd64.zip).Hash

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -8,7 +8,7 @@ cascade:
 
 ![pass-cli](/images/social-preview.svg)
 
-![Version](https://img.shields.io/github/v/release/arimxyer/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/arimxyer/pass-cli?path=docs&label=Last%20Updated)
+![Version](https://img.shields.io/github/v/release/reyamira/pass-cli?label=Version) ![Last Updated](https://img.shields.io/github/last-commit/reyamira/pass-cli?path=docs&label=Last%20Updated)
 
 Welcome to the **pass-cli** documentation. A secure, cross-platform, always-free, and open-source alternative to 1password, bitwarden, etc., Password and API key manager for folks who live in the command line. (CLI + TUI)
 
@@ -37,8 +37,8 @@ Welcome to the **pass-cli** documentation. A secure, cross-platform, always-free
 
 ## Getting Help
 
-- **GitHub Issues**: [Report bugs or request features](https://github.com/arimxyer/pass-cli/issues)
-- **GitHub Discussions**: [Ask questions and share ideas](https://github.com/arimxyer/pass-cli/discussions)
+- **GitHub Issues**: [Report bugs or request features](https://github.com/reyamira/pass-cli/issues)
+- **GitHub Discussions**: [Ask questions and share ideas](https://github.com/reyamira/pass-cli/discussions)
 - **Documentation**: You're reading it!
 
 ## Contributing

--- a/docsite/hugo.yaml
+++ b/docsite/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: https://arimxyer.github.io/pass-cli/
+baseURL: https://reyamira.github.io/pass-cli/
 languageCode: en-us
 title: PASS-CLI
 
@@ -38,7 +38,7 @@ menu:
       params:
         type: search
     - name: GitHub
-      url: https://github.com/arimxyer/pass-cli
+      url: https://github.com/reyamira/pass-cli
       weight: 1
       params:
         icon: github

--- a/homebrew/pass-cli.rb
+++ b/homebrew/pass-cli.rb
@@ -1,27 +1,27 @@
 class PassCli < Formula
   desc "Secure CLI password manager with AES-256-GCM encryption"
-  homepage "https://github.com/arimxyer/pass-cli"
+  homepage "https://github.com/reyamira/pass-cli"
   version "0.8.51"
   license "MIT"
 
   on_macos do
     on_intel do
-      url "https://github.com/arimxyer/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_darwin_amd64.tar.gz"
+      url "https://github.com/reyamira/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_darwin_amd64.tar.gz"
       sha256 "REPLACE_WITH_ACTUAL_SHA256_FOR_DARWIN_AMD64"
     end
     on_arm do
-      url "https://github.com/arimxyer/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_darwin_arm64.tar.gz"
+      url "https://github.com/reyamira/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_darwin_arm64.tar.gz"
       sha256 "REPLACE_WITH_ACTUAL_SHA256_FOR_DARWIN_ARM64"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/arimxyer/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_linux_amd64.tar.gz"
+      url "https://github.com/reyamira/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_linux_amd64.tar.gz"
       sha256 "REPLACE_WITH_ACTUAL_SHA256_FOR_LINUX_AMD64"
     end
     on_arm do
-      url "https://github.com/arimxyer/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_linux_arm64.tar.gz"
+      url "https://github.com/reyamira/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_linux_arm64.tar.gz"
       sha256 "REPLACE_WITH_ACTUAL_SHA256_FOR_LINUX_ARM64"
     end
   end
@@ -54,7 +54,7 @@ class PassCli < Formula
         • Usage tracking and audit logging
 
       Vault location: ~/.pass-cli/vault.enc
-      Complete guide: https://github.com/arimxyer/pass-cli/blob/main/docs/GETTING_STARTED.md
+      Complete guide: https://github.com/reyamira/pass-cli/blob/main/docs/GETTING_STARTED.md
     EOS
   end
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -200,7 +200,7 @@ theme: "dracula"
 #   remote: "dropbox:Apps/pass-cli" # Dropbox
 #   remote: "onedrive:Documents/pass-cli" # OneDrive
 #
-# See: https://arimxyer.github.io/pass-cli/docs/02-guides/sync-guide/
+# See: https://reyamira.github.io/pass-cli/docs/02-guides/sync-guide/
 
 # Terminal size warning configuration
 terminal:

--- a/manifests/winget/README.md
+++ b/manifests/winget/README.md
@@ -17,7 +17,7 @@ After the release is built, update `pass-cli.yaml` with the actual SHA256 hashes
 ```powershell
 # Get checksums from the GitHub release checksums.txt file
 # Replace VERSION with actual release version
-curl -L https://github.com/arimxyer/pass-cli/releases/download/vVERSION/checksums.txt
+curl -L https://github.com/reyamira/pass-cli/releases/download/vVERSION/checksums.txt
 ```
 
 Replace `PLACEHOLDER_HASH_AMD64` and `PLACEHOLDER_HASH_ARM64` with the actual SHA256 values.

--- a/manifests/winget/pass-cli.yaml
+++ b/manifests/winget/pass-cli.yaml
@@ -7,12 +7,12 @@ PackageVersion: 1.0.0
 PackageLocale: en-US
 Publisher: arimxyer
 PublisherUrl: https://github.com/arimxyer
-PublisherSupportUrl: https://github.com/arimxyer/pass-cli/issues
+PublisherSupportUrl: https://github.com/reyamira/pass-cli/issues
 Author: arimxyer
 PackageName: Pass-CLI
-PackageUrl: https://github.com/arimxyer/pass-cli
+PackageUrl: https://github.com/reyamira/pass-cli
 License: MIT
-LicenseUrl: https://github.com/arimxyer/pass-cli/blob/main/LICENSE
+LicenseUrl: https://github.com/reyamira/pass-cli/blob/main/LICENSE
 Copyright: Copyright (c) 2025 arimxyer
 ShortDescription: A secure, cross-platform CLI password and API key manager for developers
 Description: |-
@@ -42,7 +42,7 @@ Tags:
 Installers:
   - Architecture: x64
     InstallerType: zip
-    InstallerUrl: https://github.com/arimxyer/pass-cli/releases/download/v1.0.0/pass-cli_1.0.0_windows_x86_64.zip
+    InstallerUrl: https://github.com/reyamira/pass-cli/releases/download/v1.0.0/pass-cli_1.0.0_windows_x86_64.zip
     InstallerSha256: PLACEHOLDER_HASH_AMD64
     NestedInstallerFiles:
       - RelativeFilePath: pass-cli.exe
@@ -50,7 +50,7 @@ Installers:
 
   - Architecture: arm64
     InstallerType: zip
-    InstallerUrl: https://github.com/arimxyer/pass-cli/releases/download/v1.0.0/pass-cli_1.0.0_windows_arm64.zip
+    InstallerUrl: https://github.com/reyamira/pass-cli/releases/download/v1.0.0/pass-cli_1.0.0_windows_arm64.zip
     InstallerSha256: PLACEHOLDER_HASH_ARM64
     NestedInstallerFiles:
       - RelativeFilePath: pass-cli.exe

--- a/scoop/pass-cli.json
+++ b/scoop/pass-cli.json
@@ -1,29 +1,29 @@
 {
   "version": "0.8.51",
   "description": "Secure CLI password manager with AES-256-GCM encryption",
-  "homepage": "https://github.com/arimxyer/pass-cli",
+  "homepage": "https://github.com/reyamira/pass-cli",
   "license": "MIT",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/arimxyer/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_windows_amd64.zip",
+      "url": "https://github.com/reyamira/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_windows_amd64.zip",
       "hash": "REPLACE_WITH_ACTUAL_SHA256_FOR_WINDOWS_AMD64"
     },
     "arm64": {
-      "url": "https://github.com/arimxyer/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_windows_arm64.zip",
+      "url": "https://github.com/reyamira/pass-cli/releases/download/v0.0.1/pass-cli_0.0.1_windows_arm64.zip",
       "hash": "REPLACE_WITH_ACTUAL_SHA256_FOR_WINDOWS_ARM64"
     }
   },
   "bin": "pass-cli.exe",
   "checkver": {
-    "github": "https://github.com/arimxyer/pass-cli"
+    "github": "https://github.com/reyamira/pass-cli"
   },
   "autoupdate": {
     "architecture": {
       "64bit": {
-        "url": "https://github.com/arimxyer/pass-cli/releases/download/v$version/pass-cli_$version_windows_amd64.zip"
+        "url": "https://github.com/reyamira/pass-cli/releases/download/v$version/pass-cli_$version_windows_amd64.zip"
       },
       "arm64": {
-        "url": "https://github.com/arimxyer/pass-cli/releases/download/v$version/pass-cli_$version_windows_arm64.zip"
+        "url": "https://github.com/reyamira/pass-cli/releases/download/v$version/pass-cli_$version_windows_arm64.zip"
       }
     },
     "hash": {
@@ -42,7 +42,7 @@
     "Write-Host '  pass-cli doctor   - Run health checks'",
     "Write-Host ''",
     "Write-Host 'Your vault will be stored at: ~\\.pass-cli\\vault.enc' -ForegroundColor Cyan",
-    "Write-Host 'Complete guide: https://github.com/arimxyer/pass-cli/blob/main/docs/GETTING_STARTED.md'"
+    "Write-Host 'Complete guide: https://github.com/reyamira/pass-cli/blob/main/docs/GETTING_STARTED.md'"
   ],
   "notes": [
     "Pass-CLI: Secure password manager with TUI and CLI interfaces",
@@ -62,6 +62,6 @@
     "  pass-cli keychain enable - Enable auto-unlock",
     "  pass-cli doctor          - Verify vault health",
     "",
-    "Documentation: https://github.com/arimxyer/pass-cli/blob/main/docs/GETTING_STARTED.md"
+    "Documentation: https://github.com/reyamira/pass-cli/blob/main/docs/GETTING_STARTED.md"
   ]
 }


### PR DESCRIPTION
## Why

The repo transferred from the `arimxyer` org to **`reyamira`** (old URLs now redirect). **0.18.0 is the first release since the transfer**, and `.goreleaser.yml` still targeted `arimxyer/homebrew-tap`, `arimxyer/scoop-bucket`, and `arimxyer/pass-cli` for publishing — which would likely fail (tokens don't write through redirects) or land in the wrong place. This sweep fixes the publish targets and every other repo/web reference. **Supersedes the long-stale #92.**

## What changed (38 files)

- **Release/publish:** `.goreleaser.yml` — `release.github.owner` + brew/scoop `repository.owner` → `reyamira`; homepage, install snippets, changelog URLs. `homebrew/pass-cli.rb`, `scoop/pass-cli.json` — homepage, release-download, autoupdate/checkver URLs.
- **Runtime (Go strings, not imports):** `cmd/doctor.go` update-check slug → `reyamira/pass-cli`; `cmd/root.go`, `cmd/keychain_status.go`, `internal/config/config.go` help/doc URLs.
- **Docs & web:** `README`, `SECURITY`, `CONTRIBUTING`, all `docs/**`, `docsite/hugo.yaml`, issue templates, `docs-validation.yml`, winget manifest URLs, `.doc-manager` — badges, Pages URLs, repo links.

## Deliberately kept as `arimxyer` (identity / module path — not repo references)

- Go module path (`go.mod`, `docsite/go.mod`, all `.go` imports) and the `.goreleaser.yml` ldflags that inject into it — **the module path intentionally stays `arimxyer`**.
- CHANGELOG history of the prior `ari1110`→`arimxyer` rename.
- winget `Publisher`/`Author`/`Copyright`/`PackageIdentifier`/`PublisherUrl` (publisher identity).
- `issue-management.yml` `assignees: ['arimxyer']` (GitHub username).

## Verification

- `go build ./...` ✓, `go vet` ✓, `.goreleaser.yml` valid YAML with all 3 owners → `reyamira` ✓
- A dedicated verify agent + an independent residual grep: zero missed repo URLs, zero over-application into module/import/ldflags paths.
- Caught & fixed one agent slip: `docs/README.md` (a symlink → `_index.md`) was flattened into a regular file; restored as a symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
