### PR TITLE
ci: harden release pipeline (#113, #114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,26 +2,20 @@ name: CI
 
 on:
   workflow_dispatch:
+  # NOTE: no paths-ignore on either push or pull_request. The required status
+  # checks (Lint, Unit Tests, Build, Integration Tests) are ruleset requirements
+  # on both the `main` branch and the `refs/tags/v*` release tags, so they must
+  # *report* on every main commit and every PR — otherwise (a) a PR can never
+  # merge, and (b) a `v*` tag created on a docs-only commit is rejected because
+  # the checks never ran on that SHA (see #114). The jobs below already
+  # short-circuit to success via "Skip if no code changes" when check-changes
+  # finds no Go/build files, so non-code pushes/PRs (docs, skills, .gitignore)
+  # still satisfy the required checks in seconds. A workflow-level paths-ignore
+  # would suppress the whole workflow and leave those commits/PRs blocked.
   push:
     branches: [main]
     tags-ignore:
       - 'v*'
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'specs/**'
-      - '.specify/**'
-      - 'CLAUDE.md'
-      - 'CONTRIBUTING.md'
-      - 'LICENSE'
-      - '.gitignore'
-  # NOTE: no paths-ignore here. The required status checks (Lint, Unit Tests,
-  # Build, Integration Tests) are branch-ruleset requirements, so they must
-  # *report* on every PR or the PR can never merge. The jobs below already
-  # short-circuit to success via "Skip if no code changes" when check-changes
-  # finds no Go/build files, so non-code PRs (docs, skills, .gitignore) still
-  # satisfy the required checks in seconds. A workflow-level paths-ignore would
-  # suppress the whole workflow and leave those PRs blocked forever.
   pull_request:
     branches: [main]
 
@@ -216,5 +210,10 @@ jobs:
         if: needs.check-changes.outputs.code-changed == 'true'
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          # Pinned (not `latest`) so GoReleaser upgrades are deliberate and get
+          # exercised by this snapshot Build job before they can affect a real
+          # release. `latest` silently rolls forward at tag time — a future
+          # GoReleaser that removes the deprecated `brews:` key would otherwise
+          # break the release with no advance warning (see #113).
+          version: v2.16.0
           args: build --snapshot --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,10 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          # Pinned to a known-good version (see #113). Bump deliberately after the
+          # CI snapshot Build job has exercised the new version, never via `latest`,
+          # so a GoReleaser change can't break a release after the tag is created.
+          version: v2.16.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Hardens the release pipeline against two footguns surfaced during the v0.18.0 release.

### #114 — docs-only releases can now be tagged

Removes `paths-ignore` from `ci.yml`'s `push:` trigger so docs-only commits to `main` also run **Lint / Unit Tests / Build**. Those jobs already short-circuit to success in seconds via the "Skip if no code changes" steps, so non-code pushes stay cheap — but the required checks now *report* on every `main` commit. That lets a `v*` tag created on a docs-only commit satisfy the "Protect Release Tags" ruleset (previously rejected with `3 of 3 required status checks are expected`, because the checks never ran on that SHA). The tag ruleset itself is left untouched — no protection weakening.

### #113 (interim) — pin GoReleaser to a known-good version

Pins GoReleaser to `v2.16.0` in both `ci.yml` (snapshot Build) and `release.yml` instead of `version: latest`, so GoReleaser upgrades are deliberate and get exercised by the snapshot Build job before they can affect a real release. Prevents a future GoReleaser that removes the deprecated `brews:` key from silently breaking a release *after* a `v*` tag already exists.

Resolving the `brews:` deprecation itself is deferred to two mutually-exclusive follow-ups: **#117** (native per-platform: cask + nfpm) and **#118** (CI-maintained unified formula).

## Verification

- Both workflows parse (`yaml.safe_load`).
- Traced the #114 skip logic: a docs-only push to `main` → `check-changes` sets `code-changed=false` → Lint / Unit Tests / Build skip-to-success, integration-tests is skipped (push, not PR), Build still runs (a skipped dependency is not a failure) → all three tag-ruleset checks land green on the SHA, so the `v*` tag push is accepted.

Closes #114.
Refs #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
