### PR TITLE
perf(sync): fix unlock/sync latency — probe timeout + TTL-gate (+ timing)

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/arimxyer/pass-cli/internal/crypto"
 	"github.com/arimxyer/pass-cli/internal/recovery"
+	"github.com/arimxyer/pass-cli/internal/timing"
 	"github.com/arimxyer/pass-cli/internal/vault"
 	"os"
 	"path/filepath"
@@ -411,6 +412,7 @@ func unlockVault(vaultService *vault.VaultService) error {
 //     touches only the password + pre-read key params, so it overlaps the pull and
 //     we decrypt after the join (Tier 2).
 func unlockVaultWithSync(vaultService *vault.VaultService) error {
+	defer timing.Track("unlockVaultWithSync (wall)")()
 	// No pull to overlap (sync disabled or --offline): today's exact behavior.
 	if IsOffline() || !vaultService.IsSyncEnabled() {
 		syncPullBeforeUnlock(vaultService) // no-op in these cases

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,11 @@ type TerminalConfig struct {
 type SyncConfig struct {
 	Enabled bool   `mapstructure:"enabled"` // Enable/disable sync
 	Remote  string `mapstructure:"remote"`  // rclone remote name + path (e.g., "gdrive:.pass-cli")
+	// PullTTLSeconds gates the pre-unlock remote probe: within this window a
+	// command serves the local vault without a remote round-trip (writes still do
+	// a fresh conflict check at push time). 0 uses the built-in default (30s); a
+	// negative value disables the gate (probe on every command).
+	PullTTLSeconds int `mapstructure:"pull_ttl_seconds"`
 }
 
 // ValidationResult represents the outcome of checking configuration correctness

--- a/internal/sync/state.go
+++ b/internal/sync/state.go
@@ -18,6 +18,11 @@ type SyncState struct {
 	LastPushTime  time.Time `json:"last_push_time"`
 	RemoteModTime time.Time `json:"remote_mod_time"`
 	RemoteSize    int64     `json:"remote_size"`
+	// LastPullCheck is when we last successfully contacted the remote (a
+	// metadata probe or a post-push refresh). The TTL-gate skips the probe while
+	// this is within the configured window, so a burst of commands makes one
+	// remote round-trip instead of one per command.
+	LastPullCheck time.Time `json:"last_pull_check"`
 }
 
 // LoadState reads the sync state from the vault directory.

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/arimxyer/pass-cli/internal/config"
+	"github.com/arimxyer/pass-cli/internal/timing"
 )
 
 // ErrSyncConflict indicates both local and remote have changed since last sync.
@@ -217,6 +218,7 @@ func (s *Service) Push(vaultDir string) error {
 
 // CheckRemoteMetadata fetches remote file metadata using rclone lsjson.
 func (s *Service) CheckRemoteMetadata() ([]RemoteFileInfo, error) {
+	defer timing.Track("rclone lsjson (probe)")()
 	// Note: no "--hash" flag — RemoteFileInfo carries no hash field and no
 	// decision uses a remote hash (skip compares ModTime+Size; conflict detection
 	// uses a local sha256 via HashFile). Requesting it only adds backend cost.
@@ -235,6 +237,7 @@ func (s *Service) CheckRemoteMetadata() ([]RemoteFileInfo, error) {
 // SmartPull checks remote metadata and only pulls if remote has changed.
 // Returns ErrSyncConflict if both local and remote have changed.
 func (s *Service) SmartPull(vaultPath string) error {
+	defer timing.Track("SmartPull total")()
 	if !s.IsEnabled() {
 		return nil
 	}
@@ -313,7 +316,10 @@ func (s *Service) SmartPull(vaultPath string) error {
 		return fmt.Errorf("failed to create vault directory: %w", err)
 	}
 
-	if err := s.executor.RunNoOutput("rclone", "sync", s.config.Remote, vaultDir, "--exclude", syncStateFile); err != nil {
+	if err := func() error {
+		defer timing.Track("rclone sync (pull)")()
+		return s.executor.RunNoOutput("rclone", "sync", s.config.Remote, vaultDir, "--exclude", syncStateFile)
+	}(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: sync pull failed: %v\n", err)
 		return nil
 	}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -156,18 +156,40 @@ func writeLocalMarker(vaultDir, vaultFileName, hash string) error {
 	return os.WriteFile(markerPath, nil, 0600)
 }
 
+// defaultPullTTL is how long a successful remote check is trusted before the
+// pre-unlock probe is made again. Within this window commands serve the local
+// vault without a remote round-trip; writes still do a fresh conflict check at
+// push time (see SmartPush), so freshness is traded only for read latency.
+const defaultPullTTL = 30 * time.Second
+
 // Service provides vault synchronization using rclone.
 type Service struct {
 	config          config.SyncConfig
 	executor        CommandExecutor
 	skipBinaryCheck bool // bypasses rclone PATH check when using mock executor in tests
+
+	// pullTTL gates the pre-unlock remote probe. Zero disables the gate (every
+	// call probes) — the default for the mock-executor test constructor.
+	pullTTL time.Duration
+	// pullSkipped records whether the most recent SmartPull skipped the probe via
+	// the TTL gate. When true, SmartPush does its own conflict check before
+	// pushing so it never blind-overwrites a newer remote.
+	pullSkipped bool
 }
 
 // NewService creates a new sync service with the given configuration.
 func NewService(cfg config.SyncConfig) *Service {
+	ttl := defaultPullTTL
+	switch {
+	case cfg.PullTTLSeconds > 0:
+		ttl = time.Duration(cfg.PullTTLSeconds) * time.Second
+	case cfg.PullTTLSeconds < 0:
+		ttl = 0 // explicitly disabled
+	}
 	return &Service{
 		config:   cfg,
 		executor: &execExecutor{runTimeout: defaultProbeTimeout},
+		pullTTL:  ttl,
 	}
 }
 
@@ -260,8 +282,14 @@ func (s *Service) CheckRemoteMetadata() ([]RemoteFileInfo, error) {
 	return files, nil
 }
 
-// SmartPull checks remote metadata and only pulls if remote has changed.
+// SmartPull checks remote metadata and only pulls if the remote has changed.
 // Returns ErrSyncConflict if both local and remote have changed.
+//
+// It is TTL-gated: if the remote was successfully contacted within pullTTL, the
+// (variable-latency) probe is skipped and the local vault is served as-is. When
+// skipped, pullSkipped is set so a subsequent SmartPush does its own conflict
+// check before pushing — preserving the invariant that a push never blind-
+// overwrites a newer remote (see cmd/helpers.go syncPushAfterCommand).
 func (s *Service) SmartPull(vaultPath string) error {
 	defer timing.Track("SmartPull total")()
 	if !s.IsEnabled() {
@@ -275,11 +303,31 @@ func (s *Service) SmartPull(vaultPath string) error {
 
 	vaultDir := filepath.Dir(vaultPath)
 
+	// TTL-gate: skip the remote probe if we contacted the remote recently.
+	s.pullSkipped = false
+	if s.pullTTL > 0 {
+		if state, err := LoadState(vaultDir); err == nil &&
+			!state.LastPullCheck.IsZero() &&
+			time.Since(state.LastPullCheck) < s.pullTTL {
+			s.pullSkipped = true
+			return nil
+		}
+	}
+
+	return s.pullFromRemote(vaultPath, vaultDir)
+}
+
+// pullFromRemote is the un-gated pull: it probes the remote, pulls when the
+// remote changed (with conflict detection), and stamps LastPullCheck on any
+// clean outcome so the TTL gate can skip subsequent probes. A conflict
+// deliberately does NOT stamp the check, so it keeps being re-detected until the
+// user resolves it.
+func (s *Service) pullFromRemote(vaultPath, vaultDir string) error {
 	// 1. Check remote metadata
 	remoteFiles, err := s.CheckRemoteMetadata()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to check remote state: %v\n", err)
-		return nil // Allow offline operation
+		return nil // Allow offline operation (do not stamp LastPullCheck)
 	}
 
 	// Find vault.enc in remote files
@@ -292,16 +340,17 @@ func (s *Service) SmartPull(vaultPath string) error {
 		}
 	}
 
-	// No remote vault file = nothing to pull
-	if remoteVault == nil {
-		return nil
-	}
-
 	// 2. Load sync state
 	state, err := LoadState(vaultDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to load sync state: %v\n", err)
 		state = &SyncState{}
+	}
+
+	// No remote vault file = nothing to pull (but we did contact the remote).
+	if remoteVault == nil {
+		s.recordPullCheck(vaultDir, state)
+		return nil
 	}
 
 	// 3. Decide whether the remote changed since our last push.
@@ -325,11 +374,13 @@ func (s *Service) SmartPull(vaultPath string) error {
 		remoteChanged = !remoteVault.ModTime.Equal(state.RemoteModTime) || remoteVault.Size != state.RemoteSize
 	}
 	if !remoteChanged {
+		s.recordPullCheck(vaultDir, state)
 		return nil // Remote unchanged, skip pull
 	}
 
 	// 4. Remote changed — if local also diverged from our last push, it's a
-	// conflict (both sides changed). This is content-based on both sides.
+	// conflict (both sides changed). This is content-based on both sides. Do NOT
+	// stamp the check on a conflict, so it keeps being re-detected until resolved.
 	if _, statErr := os.Stat(vaultPath); statErr == nil {
 		localHash, hashErr := HashFile(vaultPath)
 		if hashErr == nil && state.LastPushHash != "" && localHash != state.LastPushHash {
@@ -359,15 +410,58 @@ func (s *Service) SmartPull(vaultPath string) error {
 		state.LastPushHash = newHash
 	}
 
-	if err := SaveState(vaultDir, state); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to save sync state: %v\n", err)
-	}
-
+	s.recordPullCheck(vaultDir, state)
 	return nil
 }
 
+// recordPullCheck stamps the TTL clock (LastPullCheck) and persists the state.
+// Called on every clean remote contact so the gate can skip subsequent probes.
+func (s *Service) recordPullCheck(vaultDir string, state *SyncState) {
+	state.LastPullCheck = time.Now()
+	if err := SaveState(vaultDir, state); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to save sync state: %v\n", err)
+	}
+}
+
+// remoteChangedSinceLastPush probes the remote and reports whether it changed
+// since our last push. It is the push-time conflict check for a TTL-skipped pull
+// and NEVER writes the local vault — unlike a pull, it cannot overwrite the
+// changes we are about to push. On a probe error it returns (false, nil),
+// matching the pre-existing posture that an unreachable remote does not block a
+// local operation (the error is already warned to the user).
+func (s *Service) remoteChangedSinceLastPush(vaultPath, vaultDir string) (bool, error) {
+	remoteFiles, err := s.CheckRemoteMetadata()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to check remote state before push: %v\n", err)
+		return false, nil
+	}
+
+	vaultFileName := filepath.Base(vaultPath)
+	var remoteVault *RemoteFileInfo
+	for i := range remoteFiles {
+		if remoteFiles[i].Name == vaultFileName {
+			remoteVault = &remoteFiles[i]
+			break
+		}
+	}
+	if remoteVault == nil {
+		return false, nil // no remote vault yet → nothing to conflict with
+	}
+
+	state, err := LoadState(vaultDir)
+	if err != nil {
+		state = &SyncState{}
+	}
+	if remoteHash, hasMarker := parseRemoteMarkerHash(remoteFiles, vaultFileName); hasMarker {
+		return remoteHash != state.LastPushHash, nil
+	}
+	return !remoteVault.ModTime.Equal(state.RemoteModTime) || remoteVault.Size != state.RemoteSize, nil
+}
+
 // SmartPush checks if local vault has changed and only pushes if needed.
-// Returns true if a push was actually performed.
+// Returns true if a push was actually performed. Returns ErrSyncConflict if the
+// pre-unlock pull was TTL-skipped and a fresh check finds the remote changed
+// under a diverged local vault — in that case nothing is pushed or overwritten.
 func (s *Service) SmartPush(vaultPath string) (bool, error) {
 	if !s.IsEnabled() {
 		return false, nil
@@ -399,6 +493,21 @@ func (s *Service) SmartPush(vaultPath string) (bool, error) {
 		return false, nil
 	}
 
+	// 3a. If the pre-unlock pull was TTL-skipped, it never checked the remote this
+	// cycle. Do a CONFLICT-ONLY check now, before pushing — never a pull, so it can
+	// never overwrite the local vault we are about to push. We are here because the
+	// local vault diverged (localHash != LastPushHash), so a remote that also
+	// changed since our last push is a conflict: abort the push, overwrite nothing.
+	if s.pullSkipped {
+		changed, err := s.remoteChangedSinceLastPush(vaultPath, vaultDir)
+		if err != nil {
+			return false, err
+		}
+		if changed {
+			return false, ErrSyncConflict
+		}
+	}
+
 	// 3b. Write the content marker (#102) into the vault dir so the rclone sync
 	// below carries it to the remote, where the next device's SmartPull reads our
 	// content hash straight from its name. Best-effort: a marker write failure
@@ -413,9 +522,11 @@ func (s *Service) SmartPush(vaultPath string) (bool, error) {
 		return false, nil
 	}
 
-	// 5. Update state
+	// 5. Update state. The push (and the metadata query below) just contacted the
+	// remote, so stamp the TTL clock — the next command can skip its probe.
 	state.LastPushHash = localHash
 	state.LastPushTime = time.Now()
+	state.LastPullCheck = time.Now()
 
 	// Query actual remote metadata after push so next SmartPull sees current state.
 	// Using time.Now() would mismatch the provider's recorded ModTime.

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -2,6 +2,7 @@
 package sync
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +16,18 @@ import (
 	"github.com/arimxyer/pass-cli/internal/timing"
 )
 
+// defaultProbeTimeout bounds the remote metadata probe (rclone lsjson). The
+// probe sits on the synchronous unlock path of every synced command, so a slow
+// or hung remote (e.g. transient Google Drive latency) must not block the CLI
+// indefinitely. On timeout the probe returns an error, which SmartPull already
+// treats as "couldn't check remote" and proceeds with the local vault — a
+// bounded, graceful degradation instead of a multi-second stall.
+//
+// Only the metadata probe (Run) is bounded. The heavy transfers (RunNoOutput —
+// the actual vault pull/push) are intentionally NOT bounded here: a real
+// transfer may legitimately take longer and must never be truncated mid-flight.
+const defaultProbeTimeout = 8 * time.Second
+
 // ErrSyncConflict indicates both local and remote have changed since last sync.
 var ErrSyncConflict = errors.New("sync conflict: both local and remote vault have changed")
 
@@ -25,10 +38,23 @@ type CommandExecutor interface {
 }
 
 // execExecutor is the real implementation using os/exec.
-type execExecutor struct{}
+type execExecutor struct {
+	// runTimeout bounds Run (the metadata probe). Zero disables the bound.
+	runTimeout time.Duration
+}
 
 func (e *execExecutor) Run(name string, args ...string) ([]byte, error) {
 	// #nosec G204 -- command args are constructed from user-configured values
+	if e.runTimeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), e.runTimeout)
+		defer cancel()
+		out, err := exec.CommandContext(ctx, name, args...).Output()
+		if ctx.Err() == context.DeadlineExceeded {
+			// Surface a clear reason instead of the process's "signal: killed".
+			return out, fmt.Errorf("timed out after %s", e.runTimeout)
+		}
+		return out, err
+	}
 	cmd := exec.Command(name, args...)
 	return cmd.Output()
 }
@@ -141,7 +167,7 @@ type Service struct {
 func NewService(cfg config.SyncConfig) *Service {
 	return &Service{
 		config:   cfg,
-		executor: &execExecutor{},
+		executor: &execExecutor{runTimeout: defaultProbeTimeout},
 	}
 }
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -600,3 +600,184 @@ func TestSmartPush_WritesContentMarker(t *testing.T) {
 		t.Errorf("stale marker should have been removed")
 	}
 }
+
+// --- TTL-gate tests (#2) ---
+
+// TestSmartPull_TTLSkipsProbeWhenRecent verifies the pre-unlock probe is skipped
+// (no rclone lsjson) when the remote was checked within the TTL window, and that
+// pullSkipped is set so a later push will do its own conflict check.
+func TestSmartPull_TTLSkipsProbeWhenRecent(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	_ = os.WriteFile(vaultPath, []byte("vault-data"), 0600)
+
+	_ = SaveState(tmpDir, &SyncState{LastPullCheck: time.Now()}) // just checked
+
+	mock := &mockExecutor{}
+	service := NewServiceWithExecutor(enabledConfig(), mock)
+	service.pullTTL = 30 * time.Second
+
+	if err := service.SmartPull(vaultPath); err != nil {
+		t.Fatalf("SmartPull returned error: %v", err)
+	}
+	if len(mock.runCalls) != 0 {
+		t.Errorf("expected 0 Run calls (probe skipped by TTL), got %d", len(mock.runCalls))
+	}
+	if !service.pullSkipped {
+		t.Error("expected pullSkipped=true when the probe was TTL-gated")
+	}
+}
+
+// TestSmartPull_TTLExpiredProbes verifies the probe runs when the last check is
+// outside the TTL window.
+func TestSmartPull_TTLExpiredProbes(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	_ = os.WriteFile(vaultPath, []byte("vault-data"), 0600)
+
+	remoteTime := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	_ = SaveState(tmpDir, &SyncState{
+		LastPullCheck: time.Now().Add(-time.Hour), // stale
+		RemoteModTime: remoteTime,
+		RemoteSize:    100,
+	})
+	lsjsonOutput, _ := json.Marshal([]RemoteFileInfo{{Name: "vault.enc", Size: 100, ModTime: remoteTime}})
+
+	mock := &mockExecutor{runOutput: lsjsonOutput}
+	service := NewServiceWithExecutor(enabledConfig(), mock)
+	service.pullTTL = 30 * time.Second
+
+	if err := service.SmartPull(vaultPath); err != nil {
+		t.Fatalf("SmartPull returned error: %v", err)
+	}
+	if len(mock.runCalls) != 1 {
+		t.Errorf("expected 1 Run call (probe, TTL expired), got %d", len(mock.runCalls))
+	}
+	if service.pullSkipped {
+		t.Error("expected pullSkipped=false when the TTL expired")
+	}
+}
+
+// TestSmartPull_StampsLastPullCheckAfterProbe verifies a successful probe records
+// the check time so the gate can skip subsequent probes.
+func TestSmartPull_StampsLastPullCheckAfterProbe(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	_ = os.WriteFile(vaultPath, []byte("vault-data"), 0600)
+
+	remoteTime := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	_ = SaveState(tmpDir, &SyncState{RemoteModTime: remoteTime, RemoteSize: 100}) // no LastPullCheck
+	lsjsonOutput, _ := json.Marshal([]RemoteFileInfo{{Name: "vault.enc", Size: 100, ModTime: remoteTime}})
+
+	mock := &mockExecutor{runOutput: lsjsonOutput}
+	service := NewServiceWithExecutor(enabledConfig(), mock)
+	service.pullTTL = 30 * time.Second
+
+	if err := service.SmartPull(vaultPath); err != nil {
+		t.Fatalf("SmartPull returned error: %v", err)
+	}
+	st, err := LoadState(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if st.LastPullCheck.IsZero() {
+		t.Error("expected LastPullCheck to be stamped after a successful probe")
+	}
+}
+
+// TestSmartPush_ConflictWhenPullSkippedAndRemoteChanged is the safety test: when
+// the pre-unlock pull was TTL-skipped and the remote has since changed under a
+// diverged local vault, SmartPush must return ErrSyncConflict and push NOTHING —
+// no blind overwrite of the newer remote.
+func TestSmartPush_ConflictWhenPullSkippedAndRemoteChanged(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	_ = os.WriteFile(vaultPath, []byte("local-modified"), 0600) // local diverged
+
+	oldTime := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	newTime := time.Date(2026, 1, 16, 12, 0, 0, 0, time.UTC)
+	_ = SaveState(tmpDir, &SyncState{
+		LastPushHash:  "hash-before-local-edit", // local hash differs → diverged
+		RemoteModTime: oldTime,
+		RemoteSize:    100,
+	})
+	// Remote changed (size/modtime differ from state) and carries no marker.
+	lsjsonOutput, _ := json.Marshal([]RemoteFileInfo{{Name: "vault.enc", Size: 200, ModTime: newTime}})
+
+	mock := &mockExecutor{runOutput: lsjsonOutput}
+	service := NewServiceWithExecutor(enabledConfig(), mock)
+	service.pullSkipped = true // simulate the pre-unlock pull having been TTL-skipped
+
+	pushed, err := service.SmartPush(vaultPath)
+	if !errors.Is(err, ErrSyncConflict) {
+		t.Errorf("expected ErrSyncConflict, got: %v", err)
+	}
+	if pushed {
+		t.Error("expected pushed=false on conflict")
+	}
+	if len(mock.runNoOutCalls) != 0 {
+		t.Errorf("SAFETY: expected 0 push calls on conflict (no overwrite), got %d", len(mock.runNoOutCalls))
+	}
+}
+
+// TestSmartPush_PushesWhenPullSkippedAndRemoteUnchanged verifies the push still
+// proceeds when the TTL-skipped pull's conflict check finds the remote unchanged.
+func TestSmartPush_PushesWhenPullSkippedAndRemoteUnchanged(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	_ = os.WriteFile(vaultPath, []byte("local-modified"), 0600)
+
+	remoteTime := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	_ = SaveState(tmpDir, &SyncState{
+		LastPushHash:  "hash-before-local-edit", // local diverged
+		RemoteModTime: remoteTime,
+		RemoteSize:    100,
+	})
+	// Remote UNCHANGED (matches state) → conflict check passes → push proceeds.
+	lsjsonOutput, _ := json.Marshal([]RemoteFileInfo{{Name: "vault.enc", Size: 100, ModTime: remoteTime}})
+
+	mock := &mockExecutor{runOutput: lsjsonOutput}
+	service := NewServiceWithExecutor(enabledConfig(), mock)
+	service.pullSkipped = true
+
+	pushed, err := service.SmartPush(vaultPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !pushed {
+		t.Error("expected pushed=true when remote is unchanged (no conflict)")
+	}
+	if len(mock.runNoOutCalls) != 1 {
+		t.Errorf("expected 1 push (rclone sync) call, got %d", len(mock.runNoOutCalls))
+	}
+}
+
+// TestSmartPush_ConflictWhenPullSkippedFirstRunEmptyHash is the regression test
+// for the earlier bug where the push-time check reused a function that could
+// PULL (overwrite local) when LastPushHash was empty. With an empty hash
+// (never-pushed / first-run state), a TTL-skipped pull and a changed remote must
+// still yield ErrSyncConflict and touch rclone for NOTHING — no pull, no push.
+func TestSmartPush_ConflictWhenPullSkippedFirstRunEmptyHash(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	_ = os.WriteFile(vaultPath, []byte("local-modified"), 0600)
+
+	remoteTime := time.Date(2026, 1, 16, 12, 0, 0, 0, time.UTC)
+	_ = SaveState(tmpDir, &SyncState{}) // LastPushHash == "", zero remote metadata
+
+	lsjsonOutput, _ := json.Marshal([]RemoteFileInfo{{Name: "vault.enc", Size: 200, ModTime: remoteTime}})
+	mock := &mockExecutor{runOutput: lsjsonOutput}
+	service := NewServiceWithExecutor(enabledConfig(), mock)
+	service.pullSkipped = true
+
+	pushed, err := service.SmartPush(vaultPath)
+	if !errors.Is(err, ErrSyncConflict) {
+		t.Errorf("expected ErrSyncConflict on empty-hash + changed remote, got: %v", err)
+	}
+	if pushed {
+		t.Error("expected pushed=false")
+	}
+	if len(mock.runNoOutCalls) != 0 {
+		t.Errorf("SAFETY: expected 0 rclone RunNoOutput calls (no pull, no push), got %d", len(mock.runNoOutCalls))
+	}
+}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -6,12 +6,53 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/arimxyer/pass-cli/internal/config"
 )
+
+// TestExecExecutor_RunTimeout verifies the metadata probe is bounded: a Run that
+// exceeds runTimeout is killed promptly and returns a clear "timed out" error
+// (which SmartPull degrades to serving the local vault). This is the guard
+// against a slow/hung remote (e.g. transient Google Drive latency) stalling
+// every synced command.
+func TestExecExecutor_RunTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses the POSIX `sleep` command")
+	}
+	e := &execExecutor{runTimeout: 100 * time.Millisecond}
+	start := time.Now()
+	_, err := e.Run("sleep", "10")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected a 'timed out' error, got: %v", err)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("timeout did not fire promptly: took %v (want << 10s)", elapsed)
+	}
+}
+
+// TestExecExecutor_RunWithinTimeout confirms a fast command still succeeds when a
+// timeout is configured (the bound only bites on overruns).
+func TestExecExecutor_RunWithinTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses the POSIX `echo` command")
+	}
+	e := &execExecutor{runTimeout: 5 * time.Second}
+	out, err := e.Run("echo", "ok")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(out), "ok") {
+		t.Errorf("expected output to contain 'ok', got %q", out)
+	}
+}
 
 // mockExecutor records calls and returns configured responses.
 type mockExecutor struct {

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -1,0 +1,52 @@
+// Package timing provides opt-in, low-overhead stage timing for diagnosing
+// latency in hot paths (notably vault unlock + cloud sync).
+//
+// It is a diagnostic aid, not a feature: instrumentation is compiled in but
+// dormant. Timing is emitted only when the PASS_CLI_TIMING environment variable
+// is set to a non-empty value other than "0". When disabled, Track performs a
+// single cached boolean check and returns a no-op closure — no allocations, no
+// syscalls, no measurable overhead on the normal path.
+//
+// Lines are written to stderr (stdout stays clean for script consumers) in the
+// form:
+//
+//	[timing] <stage>            <duration>
+package timing
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+var (
+	enabledOnce sync.Once
+	enabled     bool
+)
+
+// Enabled reports whether timing output is turned on. The environment is read
+// once and cached for the lifetime of the process.
+func Enabled() bool {
+	enabledOnce.Do(func() {
+		v := os.Getenv("PASS_CLI_TIMING")
+		enabled = v != "" && v != "0"
+	})
+	return enabled
+}
+
+// Track starts a timer for a named stage and returns a stop function that, when
+// called, emits the elapsed duration. The intended use is:
+//
+//	defer timing.Track("rclone lsjson (probe)")()
+//
+// When timing is disabled, Track returns a no-op closure and does no work.
+func Track(stage string) func() {
+	if !Enabled() {
+		return func() {}
+	}
+	start := time.Now()
+	return func() {
+		fmt.Fprintf(os.Stderr, "[timing] %-26s %v\n", stage, time.Since(start).Round(time.Microsecond))
+	}
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -17,6 +17,7 @@ import (
 	"github.com/arimxyer/pass-cli/internal/security"
 	"github.com/arimxyer/pass-cli/internal/storage"
 	intsync "github.com/arimxyer/pass-cli/internal/sync"
+	"github.com/arimxyer/pass-cli/internal/timing"
 
 	"github.com/tyler-smith/go-bip39"
 	"golang.org/x/crypto/argon2"
@@ -690,6 +691,7 @@ func (v *VaultService) InitializeWithRecovery(masterPassword []byte, useKeychain
 // T011: Updated signature to accept []byte, T015: Added deferred cleanup
 // T036e: Auto-rollback on incomplete migration detection
 func (v *VaultService) Unlock(masterPassword []byte) error {
+	defer timing.Track("vault.Unlock (derive+decrypt)")()
 	defer crypto.ClearBytes(masterPassword) // T015: Ensure cleanup even on error
 
 	if v.unlocked {
@@ -972,6 +974,7 @@ func (v *VaultService) PrepareUnlock() (*PreparedUnlock, error) {
 // parameters (no file access) — safe to call while a sync pull is in flight.
 // The returned key is handed to UnlockWithPreparedKey, which clears it.
 func (p *PreparedUnlock) DeriveDataKey(password []byte) ([]byte, error) {
+	defer timing.Track("PBKDF2 derive (keychain)")()
 	return p.storageService.DeriveDataKey(string(password), p.params)
 }
 

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -249,6 +249,14 @@ func (v *VaultService) SyncPush() bool {
 		return false
 	}
 	pushed, err := v.syncService.SmartPush(v.vaultPath)
+	if errors.Is(err, intsync.ErrSyncConflict) {
+		// The TTL-skipped pull's push-time conflict check found the remote changed
+		// under a diverged local vault. Nothing was pushed or overwritten — both
+		// sides are intact; the user resolves which to keep.
+		v.syncConflictDetected = true
+		fmt.Fprintf(os.Stderr, "Warning: sync conflict — the remote changed since your last sync, so your local change was NOT pushed (nothing was overwritten). Use `pass-cli sync resolve` to choose which version to keep.\n")
+		return false
+	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: sync push failed: %v\n", err)
 		return false


### PR DESCRIPTION
## Summary

Fixes the unlock/sync latency where every synced command blocked on an `rclone lsjson` remote probe (measured 1.7s–50s on Google Drive, ~100% of wall time). Three commits: diagnostic instrumentation → worst-case cap → common-case elimination.

### 1. `PASS_CLI_TIMING` instrumentation
New `internal/timing` package (zero overhead when off). Emits `[timing]` stage lines to stderr only when `PASS_CLI_TIMING` is set. This is what diagnosed the probe as the bottleneck (PBKDF2 was a steady ~79ms and irrelevant).

### 2. Probe timeout (caps the worst case)
The `rclone lsjson` probe now runs under an 8s `exec.CommandContext` deadline. On timeout it hits the existing graceful path ("couldn't check remote → serve local"), so a slow/hung remote degrades to a bounded fallback instead of a 50s stall. Only the metadata probe is bounded — the actual vault transfer is never truncated.

### 3. TTL-gate (removes the probe from most commands)
The probe is skipped when the remote was contacted within `pullTTL` (default 30s, configurable via `sync.pull_ttl_seconds`). A burst of commands makes one remote round-trip instead of one each.

**Conflict safety (the load-bearing part).** The pre-unlock pull doubles as pre-push conflict detection ("SmartPush's only safety is that SmartPull ran first"). When the gate skips the pull, the Service records `pullSkipped`, and a subsequent `SmartPush` runs `remoteChangedSinceLastPush` — a **conflict-only** probe that never pulls, so it cannot overwrite the local vault it is about to push. A remote that changed under a diverged local vault yields `ErrSyncConflict`: nothing pushed or overwritten, user resolves via `pass-cli sync resolve`. The dedicated checker (rather than reusing SmartPull) closes an overwrite path on empty-`LastPushHash` first-run state.

Reads improve; **writes keep today's round-trip count** (the first probe just moves from pre-unlock to push-time). `get` benefits directly because it only writes usage locally and never pushes.

## Empirical result (real Google Drive remote)

| | GET 1 (cold) | GET 2 (within 30s TTL) |
|---|---|---|
| `rclone lsjson (probe)` | 629ms | **absent — skipped** |
| `SmartPull total` | 629ms | **378µs** |
| wall | 631ms | **65ms** (~PBKDF2 only) |

~10× faster on the repeated call, and immune to the 50s tail since it never touches the network.

## Testing

- `go build`, `go vet`, `gofmt` clean; full `internal/sync`, `internal/vault`, `internal/config` suites pass.
- New tests: probe timeout kill; TTL skip/expire; `LastPullCheck` stamping; and **three conflict-safety cases** including the first-run empty-hash overwrite regression (asserts 0 rclone calls on conflict).
- Verified end-to-end against the real remote (table above).

## Notes / follow-ups

- `get`'s remaining unlock cost is PBKDF2 (~63ms); further wins need the daemon (#116) or PBKDF2 tuning.
- `sync.pull_ttl_seconds` config field is wired via mapstructure; the 30s default is what's exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
