### PR TITLE
refactor(exec): envmap grammar + resolver substrate + slash separator (#115/#116 Phase 0)

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/arimxyer/pass-cli/internal/crypto"
+	"github.com/arimxyer/pass-cli/internal/envmap"
+	"github.com/arimxyer/pass-cli/internal/resolver"
 	"github.com/arimxyer/pass-cli/internal/vault"
 )
 
@@ -74,19 +74,12 @@ func init() {
 	execCmd.Flags().StringVarP(&execField, "field", "f", "password", "field to inject for all mappings (username, password, category, url, notes, service)")
 }
 
-// envMapping pairs a target environment variable name with the credential service
-// whose field value should be injected into it. field is the optional per-mapping
-// field override ("" means fall back to the global --field flag).
-type envMapping struct {
-	envName string
-	service string
-	field   string
-}
-
 // parseExecArgs splits the parsed positional args into credential mappings and the
 // child command argv. dashIdx is cmd.ArgsLenAtDash(): the number of positional args
-// that appeared before the "--" terminator (or -1 if there was no "--").
-func parseExecArgs(sets []string, args []string, dashIdx int) (mappings []envMapping, childArgv []string, err error) {
+// that appeared before the "--" terminator (or -1 if there was no "--"). The
+// per-spec grammar lives in internal/envmap; this function owns only the exec-CLI
+// shape (the "--" split and the --set-vs-positional forms).
+func parseExecArgs(sets []string, args []string, dashIdx int) (mappings []envmap.Mapping, childArgv []string, err error) {
 	var preDash []string
 	if dashIdx < 0 {
 		// No "--" terminator at all: we cannot tell the service from the command.
@@ -104,17 +97,11 @@ func parseExecArgs(sets []string, args []string, dashIdx int) (mappings []envMap
 			return nil, nil, fmt.Errorf("cannot combine a positional <service> (%q) with --set; use one form or the other", preDash[0])
 		}
 		for _, s := range sets {
-			name, spec, ok := strings.Cut(s, "=")
-			if !ok || name == "" || spec == "" {
-				return nil, nil, fmt.Errorf("invalid --set value %q: expected ENV_NAME=service[:field]", s)
+			m, perr := envmap.ParseSetSpec(s)
+			if perr != nil {
+				return nil, nil, perr
 			}
-			// Optional per-mapping field override: service:field. The first ':'
-			// separates the service from the field, so a field always wins when present.
-			service, field, hasField := strings.Cut(spec, ":")
-			if hasField && (service == "" || field == "") {
-				return nil, nil, fmt.Errorf("invalid --set value %q: expected ENV_NAME=service:field", s)
-			}
-			mappings = append(mappings, envMapping{envName: name, service: service, field: field})
+			mappings = append(mappings, m)
 		}
 		return mappings, childArgv, nil
 	}
@@ -124,28 +111,12 @@ func parseExecArgs(sets []string, args []string, dashIdx int) (mappings []envMap
 		return nil, nil, errors.New("expected exactly one <service> before '--' (or use --set ENV_NAME=service)")
 	}
 	service := preDash[0]
-	envName := deriveEnvName(service)
+	envName := envmap.DeriveEnvName(service)
 	if envName == "" {
 		return nil, nil, fmt.Errorf("cannot derive an environment variable name from service %q; use --set ENV_NAME=%s", service, service)
 	}
-	mappings = append(mappings, envMapping{envName: envName, service: service})
+	mappings = append(mappings, envmap.Mapping{EnvName: envName, Service: service})
 	return mappings, childArgv, nil
-}
-
-// deriveEnvName converts a service name into an environment variable name:
-// uppercased, with every non-alphanumeric ASCII character replaced by '_'.
-// e.g. "openai-api" -> "OPENAI_API".
-func deriveEnvName(service string) string {
-	var b strings.Builder
-	for _, r := range strings.ToUpper(service) {
-		switch {
-		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-		default:
-			b.WriteRune('_')
-		}
-	}
-	return b.String()
 }
 
 // runChild executes the child process, inheriting the parent's stdio. It returns
@@ -200,21 +171,17 @@ func runExec(cmd *cobra.Command, args []string) error {
 	}
 	defer vaultService.Lock()
 
-	// Build the child's extra environment. exec is deliberately read-only: it does
-	// NOT call RecordFieldAccess or syncPushAfterCommand, so repeated invocations on
-	// a hot path don't mutate the vault hash and trigger a sync push every time.
-	extraEnv := make([]string, 0, len(mappings))
-	for _, m := range mappings {
-		// A per-mapping field (--set ENV=service:field) overrides the global --field.
-		field := m.field
-		if field == "" {
-			field = execField
-		}
-		entry, err := buildEnvEntry(vaultService, m, field)
-		if err != nil {
-			return err
-		}
-		extraEnv = append(extraEnv, entry)
+	// Build the child's extra environment via the shared resolver. exec is
+	// deliberately read-only: the resolver does NOT call RecordFieldAccess or
+	// syncPushAfterCommand, so repeated invocations on a hot path don't mutate the
+	// vault hash and trigger a sync push every time. The direct backend does not own
+	// the vault, so Close is a no-op; runExec owns unlock/Lock.
+	r := resolver.NewDirect(vaultService)
+	defer func() { _ = r.Close() }()
+
+	extraEnv, err := r.Resolve(mappings, execField)
+	if err != nil {
+		return err
 	}
 
 	exitCode, err := runChild(childArgv, extraEnv)
@@ -229,23 +196,4 @@ func runExec(cmd *cobra.Command, args []string) error {
 		os.Exit(exitCode)
 	}
 	return nil
-}
-
-// buildEnvEntry fetches one credential, resolves the requested field, and returns
-// the "ENV_NAME=value" string. The credential's secret bytes are cleared before the
-// function returns; the field value is read first, so the wiped bytes never affect
-// the returned string.
-func buildEnvEntry(vaultService *vault.VaultService, m envMapping, field string) (string, error) {
-	// GetCredential returns a deep copy, so clearing Password does not touch the vault.
-	cred, err := vaultService.GetCredential(m.service, false)
-	if err != nil {
-		return "", fmt.Errorf("failed to get credential %q: %w", m.service, err)
-	}
-	defer crypto.ClearBytes(cred.Password)
-
-	value, _, err := resolveCredentialField(cred, field)
-	if err != nil {
-		return "", err
-	}
-	return m.envName + "=" + value, nil
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -36,11 +36,14 @@ There are two ways to map credentials to environment variables:
   pass-cli exec openai-api -- python train.py   # sets OPENAI_API
 
 The -f/--field flag selects which field to inject (default: password) and
-applies to every mapping. A single mapping can override it with a ':field'
+applies to every mapping. A single mapping can override it with a '/field'
 suffix, which is how you inject two fields of the same entry as separate
 variables (e.g. a database username and password):
 
-  pass-cli exec --set DB_USER=postgres:username --set DB_PASSWORD=postgres:password -- ./run.sh
+  pass-cli exec --set DB_USER=postgres/username --set DB_PASSWORD=postgres/password -- ./run.sh
+
+The legacy ':field' separator ('postgres:password') is still accepted, but '/'
+is preferred: in slash form any ':' in the service name is a literal character.
 
 Everything after '--' is the command to run; pass-cli writes nothing of its
 own to stdout, and the child's exit code is propagated unchanged.
@@ -60,7 +63,7 @@ it is not process isolation.`,
   pass-cli exec --set DB_USER=postgres --field username -- ./run-migration.sh
 
   # Inject two fields of one entry as separate variables (per-mapping field override)
-  pass-cli exec --set DB_USER=postgres:username --set DB_PASSWORD=postgres:password -- ./run-migration.sh
+  pass-cli exec --set DB_USER=postgres/username --set DB_PASSWORD=postgres/password -- ./run-migration.sh
 
   # Convenience form: service name -> env name (openai-api -> OPENAI_API)
   pass-cli exec openai-api -- python train.py`,
@@ -70,7 +73,7 @@ it is not process isolation.`,
 
 func init() {
 	rootCmd.AddCommand(execCmd)
-	execCmd.Flags().StringArrayVar(&execSets, "set", nil, "map an environment variable to a credential: ENV_NAME=service[:field] (repeatable)")
+	execCmd.Flags().StringArrayVar(&execSets, "set", nil, "map an environment variable to a credential: ENV_NAME=service[/field] (repeatable; ':field' also accepted)")
 	execCmd.Flags().StringVarP(&execField, "field", "f", "password", "field to inject for all mappings (username, password, category, url, notes, service)")
 }
 

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -9,90 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/arimxyer/pass-cli/internal/vault"
+	"github.com/arimxyer/pass-cli/internal/envmap"
 )
-
-// TestResolveCredentialField verifies the shared field resolver covers every alias
-// used by both `get` and `exec`, returns the canonical name, and rejects bad fields.
-func TestResolveCredentialField(t *testing.T) {
-	cred := &vault.Credential{
-		Service:  "github",
-		Username: "octocat",
-		Password: []byte("s3cr3t-pw"),
-		Category: "vcs",
-		URL:      "https://github.com",
-		Notes:    "personal token",
-	}
-
-	tests := []struct {
-		field         string
-		wantValue     string
-		wantCanonical string
-	}{
-		{"username", "octocat", "username"},
-		{"user", "octocat", "username"},
-		{"u", "octocat", "username"},
-		{"password", "s3cr3t-pw", "password"},
-		{"pass", "s3cr3t-pw", "password"},
-		{"p", "s3cr3t-pw", "password"},
-		{"PASSWORD", "s3cr3t-pw", "password"}, // case-insensitive
-		{"category", "vcs", "category"},
-		{"cat", "vcs", "category"},
-		{"c", "vcs", "category"},
-		{"url", "https://github.com", "url"},
-		{"notes", "personal token", "notes"},
-		{"note", "personal token", "notes"},
-		{"n", "personal token", "notes"},
-		{"service", "github", "service"},
-		{"s", "github", "service"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.field, func(t *testing.T) {
-			value, canonical, err := resolveCredentialField(cred, tt.field)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if value != tt.wantValue {
-				t.Errorf("value = %q, want %q", value, tt.wantValue)
-			}
-			if canonical != tt.wantCanonical {
-				t.Errorf("canonical = %q, want %q", canonical, tt.wantCanonical)
-			}
-		})
-	}
-
-	t.Run("invalid field", func(t *testing.T) {
-		_, _, err := resolveCredentialField(cred, "totp")
-		if err == nil {
-			t.Fatal("expected error for invalid field, got nil")
-		}
-	})
-}
-
-// TestDeriveEnvName verifies service -> env var name derivation.
-func TestDeriveEnvName(t *testing.T) {
-	tests := []struct {
-		service string
-		want    string
-	}{
-		{"openai-api", "OPENAI_API"},
-		{"github", "GITHUB"},
-		{"aws.prod", "AWS_PROD"},
-		{"my service", "MY_SERVICE"},
-		{"api/v2:key", "API_V2_KEY"},
-		{"already_ok", "ALREADY_OK"},
-		{"GH123", "GH123"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.service, func(t *testing.T) {
-			if got := deriveEnvName(tt.service); got != tt.want {
-				t.Errorf("deriveEnvName(%q) = %q, want %q", tt.service, got, tt.want)
-			}
-		})
-	}
-}
 
 // TestParseExecArgs covers the credential-mapping / child-argv split, the
 // convenience form, and every error path, using a hand-set dash index.
@@ -102,7 +20,7 @@ func TestParseExecArgs(t *testing.T) {
 		sets         []string
 		args         []string
 		dashIdx      int
-		wantMappings []envMapping
+		wantMappings []envmap.Mapping
 		wantChild    []string
 		wantErr      bool
 	}{
@@ -111,7 +29,7 @@ func TestParseExecArgs(t *testing.T) {
 			sets:         []string{"GITHUB_TOKEN=github"},
 			args:         []string{"gh", "repo", "list"},
 			dashIdx:      0,
-			wantMappings: []envMapping{{"GITHUB_TOKEN", "github", ""}},
+			wantMappings: []envmap.Mapping{{EnvName: "GITHUB_TOKEN", Service: "github"}},
 			wantChild:    []string{"gh", "repo", "list"},
 		},
 		{
@@ -119,7 +37,7 @@ func TestParseExecArgs(t *testing.T) {
 			sets:         []string{"AWS_ACCESS_KEY_ID=aws-id", "AWS_SECRET_ACCESS_KEY=aws-secret"},
 			args:         []string{"aws", "s3", "ls"},
 			dashIdx:      0,
-			wantMappings: []envMapping{{"AWS_ACCESS_KEY_ID", "aws-id", ""}, {"AWS_SECRET_ACCESS_KEY", "aws-secret", ""}},
+			wantMappings: []envmap.Mapping{{EnvName: "AWS_ACCESS_KEY_ID", Service: "aws-id"}, {EnvName: "AWS_SECRET_ACCESS_KEY", Service: "aws-secret"}},
 			wantChild:    []string{"aws", "s3", "ls"},
 		},
 		{
@@ -127,7 +45,7 @@ func TestParseExecArgs(t *testing.T) {
 			sets:         nil,
 			args:         []string{"openai-api", "python", "train.py"},
 			dashIdx:      1,
-			wantMappings: []envMapping{{"OPENAI_API", "openai-api", ""}},
+			wantMappings: []envmap.Mapping{{EnvName: "OPENAI_API", Service: "openai-api"}},
 			wantChild:    []string{"python", "train.py"},
 		},
 		{
@@ -135,7 +53,7 @@ func TestParseExecArgs(t *testing.T) {
 			sets:         []string{"DB_USER=postgres:username"},
 			args:         []string{"mycmd"},
 			dashIdx:      0,
-			wantMappings: []envMapping{{"DB_USER", "postgres", "username"}},
+			wantMappings: []envmap.Mapping{{EnvName: "DB_USER", Service: "postgres", Field: "username"}},
 			wantChild:    []string{"mycmd"},
 		},
 		{
@@ -143,7 +61,7 @@ func TestParseExecArgs(t *testing.T) {
 			sets:         []string{"DB_USER=pg:username", "DB_PASSWORD=pg:password"},
 			args:         []string{"./run.sh"},
 			dashIdx:      0,
-			wantMappings: []envMapping{{"DB_USER", "pg", "username"}, {"DB_PASSWORD", "pg", "password"}},
+			wantMappings: []envmap.Mapping{{EnvName: "DB_USER", Service: "pg", Field: "username"}, {EnvName: "DB_PASSWORD", Service: "pg", Field: "password"}},
 			wantChild:    []string{"./run.sh"},
 		},
 		{
@@ -230,7 +148,7 @@ func TestParseExecArgs(t *testing.T) {
 // returned by cmd.ArgsLenAtDash() splits the positional args exactly where
 // parseExecArgs assumes. This pins our one external assumption empirically.
 func TestExecCmd_ArgsLenAtDash(t *testing.T) {
-	parse := func(argv []string) (mappings []envMapping, child []string, parseErr, execErr error) {
+	parse := func(argv []string) (mappings []envmap.Mapping, child []string, parseErr, execErr error) {
 		var sets []string
 		c := &cobra.Command{
 			Use:  "exec",
@@ -254,7 +172,7 @@ func TestExecCmd_ArgsLenAtDash(t *testing.T) {
 		if execErr != nil || parseErr != nil {
 			t.Fatalf("execErr=%v parseErr=%v", execErr, parseErr)
 		}
-		if !equalMappings(mappings, []envMapping{{"K", "svc", ""}}) {
+		if !equalMappings(mappings, []envmap.Mapping{{EnvName: "K", Service: "svc"}}) {
 			t.Errorf("mappings = %v", mappings)
 		}
 		if !equalStrings(child, []string{"mycmd", "arg1"}) {
@@ -267,7 +185,7 @@ func TestExecCmd_ArgsLenAtDash(t *testing.T) {
 		if execErr != nil || parseErr != nil {
 			t.Fatalf("execErr=%v parseErr=%v", execErr, parseErr)
 		}
-		if !equalMappings(mappings, []envMapping{{"SVC", "svc", ""}}) {
+		if !equalMappings(mappings, []envmap.Mapping{{EnvName: "SVC", Service: "svc"}}) {
 			t.Errorf("mappings = %v", mappings)
 		}
 		if !equalStrings(child, []string{"mycmd"}) {
@@ -280,7 +198,7 @@ func TestExecCmd_ArgsLenAtDash(t *testing.T) {
 		if execErr != nil || parseErr != nil {
 			t.Fatalf("execErr=%v parseErr=%v", execErr, parseErr)
 		}
-		if !equalMappings(mappings, []envMapping{{"K", "svc", ""}}) {
+		if !equalMappings(mappings, []envmap.Mapping{{EnvName: "K", Service: "svc"}}) {
 			t.Errorf("mappings = %v", mappings)
 		}
 		if !equalStrings(child, []string{"mycmd", "--child-flag", "v"}) {
@@ -402,7 +320,7 @@ func trimNewline(s string) string {
 	return s
 }
 
-func equalMappings(a, b []envMapping) bool {
+func equalMappings(a, b []envmap.Mapping) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -139,7 +139,7 @@ func runGet(cmd *cobra.Command, args []string) error {
 
 func outputQuietMode(cred *vault.Credential, vaultService *vault.VaultService, service string) error {
 	// Shared field resolver keeps the valid-field list in sync with `exec`.
-	value, fieldName, err := resolveCredentialField(cred, getField)
+	value, fieldName, err := vault.ResolveCredentialField(cred, getField)
 	if err != nil {
 		return err
 	}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -270,33 +270,6 @@ func formatUsageTable(records []vault.UsageRecord) string {
 	return builder.String()
 }
 
-// resolveCredentialField returns the requested field's value from a credential
-// along with its canonical name (for usage tracking). It is the single source of
-// truth for the field aliases accepted by `get` and `exec`, keeping the valid-field
-// list from drifting between the two commands.
-//
-// Security note: for the password field this returns string(cred.Password); the
-// caller is responsible for clearing the source []byte (crypto.ClearBytes) and for
-// never printing or copying the value where the brief forbids it.
-func resolveCredentialField(cred *vault.Credential, field string) (value string, canonical string, err error) {
-	switch strings.ToLower(field) {
-	case "username", "user", "u":
-		return cred.Username, "username", nil
-	case "password", "pass", "p":
-		return string(cred.Password), "password", nil
-	case "category", "cat", "c":
-		return cred.Category, "category", nil
-	case "url":
-		return cred.URL, "url", nil
-	case "notes", "note", "n":
-		return cred.Notes, "notes", nil
-	case "service", "s":
-		return cred.Service, "service", nil
-	default:
-		return "", "", fmt.Errorf("invalid field: %s (valid: username, password, category, url, notes, service)", field)
-	}
-}
-
 // initVaultAndStorage initializes vault service and returns both vault and storage services
 // This pattern is common across backup commands to avoid code duplication
 func initVaultAndStorage(vaultPath string) (*vault.VaultService, error) {

--- a/internal/envmap/envmap.go
+++ b/internal/envmap/envmap.go
@@ -1,0 +1,57 @@
+// Package envmap holds the shared grammar for mapping stored credentials to
+// environment variables: the Mapping type, env-name derivation, and the parser
+// for a single "NAME=service[:field]" spec.
+//
+// It is the single home for this grammar so that every surface that consumes it
+// — `exec --set`, the project manifest, and (later) `${pass:...}` templates —
+// parses the same way. Phase 0a extracts today's colon grammar verbatim; Phase 0b
+// adds the slash-delimited form additively (see the plan's §3.1).
+package envmap
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Mapping pairs a target environment variable name with the credential service
+// whose field value should be injected into it. Field is the optional per-mapping
+// field override ("" means fall back to the caller's default field).
+type Mapping struct {
+	EnvName string
+	Service string
+	Field   string
+}
+
+// ParseSetSpec parses a single "NAME=service[:field]" spec into a Mapping. The
+// first ':' separates the service from an optional field override, so a field
+// always wins when present. An empty name, empty service, or (when a ':' is
+// present) empty service/field is an error.
+func ParseSetSpec(spec string) (Mapping, error) {
+	name, rest, ok := strings.Cut(spec, "=")
+	if !ok || name == "" || rest == "" {
+		return Mapping{}, fmt.Errorf("invalid mapping %q: expected NAME=service[:field]", spec)
+	}
+	// Optional per-mapping field override: service:field. The first ':' separates
+	// the service from the field, so a field always wins when present.
+	service, field, hasField := strings.Cut(rest, ":")
+	if hasField && (service == "" || field == "") {
+		return Mapping{}, fmt.Errorf("invalid mapping %q: expected NAME=service:field", spec)
+	}
+	return Mapping{EnvName: name, Service: service, Field: field}, nil
+}
+
+// DeriveEnvName converts a service name into an environment variable name:
+// uppercased, with every non-alphanumeric ASCII character replaced by '_'.
+// e.g. "openai-api" -> "OPENAI_API".
+func DeriveEnvName(service string) string {
+	var b strings.Builder
+	for _, r := range strings.ToUpper(service) {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}

--- a/internal/envmap/envmap.go
+++ b/internal/envmap/envmap.go
@@ -22,22 +22,53 @@ type Mapping struct {
 	Field   string
 }
 
-// ParseSetSpec parses a single "NAME=service[:field]" spec into a Mapping. The
-// first ':' separates the service from an optional field override, so a field
-// always wins when present. An empty name, empty service, or (when a ':' is
-// present) empty service/field is an error.
+// ParseSetSpec parses a single "NAME=service[/field]" spec into a Mapping. The
+// path is split by SplitPath: slash is the preferred separator, with the legacy
+// colon form still accepted. An empty name or empty service is an error.
 func ParseSetSpec(spec string) (Mapping, error) {
 	name, rest, ok := strings.Cut(spec, "=")
 	if !ok || name == "" || rest == "" {
-		return Mapping{}, fmt.Errorf("invalid mapping %q: expected NAME=service[:field]", spec)
+		return Mapping{}, fmt.Errorf("invalid mapping %q: expected NAME=service[/field]", spec)
 	}
-	// Optional per-mapping field override: service:field. The first ':' separates
-	// the service from the field, so a field always wins when present.
-	service, field, hasField := strings.Cut(rest, ":")
-	if hasField && (service == "" || field == "") {
-		return Mapping{}, fmt.Errorf("invalid mapping %q: expected NAME=service:field", spec)
+	service, field, err := SplitPath(rest)
+	if err != nil {
+		return Mapping{}, fmt.Errorf("invalid mapping %q: %w", spec, err)
 	}
 	return Mapping{EnvName: name, Service: service, Field: field}, nil
+}
+
+// SplitPath splits a "service[/field]" credential reference into its service and
+// optional field. It is the single home for the path separator, shared by
+// --set, the project manifest, and ${pass:...} templates.
+//
+//   - Slash is preferred and wins: if the reference contains '/', it is split on
+//     '/', and any ':' in it is a literal character (the fragility fix). Exactly
+//     one slash — two segments, service/field — is accepted for now; three or
+//     more segments error, reserving vault/service/field for a future multi-vault.
+//   - Otherwise the legacy colon form applies, byte-for-byte the original
+//     behavior: the first ':' separates service from an optional field.
+//   - With no separator at all, the whole reference is the service and the field
+//     is empty (the caller falls back to its default field).
+func SplitPath(ref string) (service, field string, err error) {
+	if strings.Contains(ref, "/") {
+		segs := strings.Split(ref, "/")
+		if len(segs) > 2 {
+			return "", "", fmt.Errorf("multi-segment paths not yet supported (expected service/field): %q", ref)
+		}
+		service, field = segs[0], segs[1]
+		if service == "" || field == "" {
+			return "", "", fmt.Errorf("expected service/field: %q", ref)
+		}
+		return service, field, nil
+	}
+
+	// Legacy colon form: the first ':' separates the service from the field, so a
+	// field always wins when present.
+	service, field, hasField := strings.Cut(ref, ":")
+	if hasField && (service == "" || field == "") {
+		return "", "", fmt.Errorf("expected service:field: %q", ref)
+	}
+	return service, field, nil
 }
 
 // DeriveEnvName converts a service name into an environment variable name:

--- a/internal/envmap/envmap_test.go
+++ b/internal/envmap/envmap_test.go
@@ -26,9 +26,9 @@ func TestDeriveEnvName(t *testing.T) {
 	}
 }
 
-// TestParseSetSpec covers the per-spec grammar: NAME=service, the ':field'
-// override, and every error path. This is the colon grammar extracted verbatim
-// from cmd/exec.go in Phase 0a; the slash form is added in 0b.
+// TestParseSetSpec covers the per-spec grammar for both separators. The colon
+// cases are the Phase 0a behavior and must stay green as the back-compat proof;
+// the slash cases are the additive Phase 0b form.
 func TestParseSetSpec(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -36,13 +36,20 @@ func TestParseSetSpec(t *testing.T) {
 		want    Mapping
 		wantErr bool
 	}{
+		// --- legacy colon form (back-compat, unchanged) ---
 		{name: "service only", spec: "GITHUB_TOKEN=github", want: Mapping{"GITHUB_TOKEN", "github", ""}},
-		{name: "field override", spec: "DB_USER=postgres:username", want: Mapping{"DB_USER", "postgres", "username"}},
+		{name: "colon field override", spec: "DB_USER=postgres:username", want: Mapping{"DB_USER", "postgres", "username"}},
 		{name: "empty field after colon", spec: "K=svc:", wantErr: true},
 		{name: "empty service before colon", spec: "K=:username", wantErr: true},
 		{name: "no equals", spec: "NOEQUALS", wantErr: true},
 		{name: "empty service", spec: "K=", wantErr: true},
 		{name: "empty name", spec: "=github", wantErr: true},
+		// --- additive slash form (Phase 0b) ---
+		{name: "slash field", spec: "DB_USER=postgres/username", want: Mapping{"DB_USER", "postgres", "username"}},
+		{name: "slash colon is literal in service", spec: "URL=my:svc/password", want: Mapping{"URL", "my:svc", "password"}},
+		{name: "slash empty field", spec: "K=svc/", wantErr: true},
+		{name: "slash empty service", spec: "K=/field", wantErr: true},
+		{name: "slash multi-segment reserved", spec: "K=vault/svc/field", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -59,6 +66,44 @@ func TestParseSetSpec(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("ParseSetSpec(%q) = %+v, want %+v", tt.spec, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSplitPath exercises the shared separator directly, including the
+// slash-wins / colon-literal rule that later surfaces (manifest, templates) rely on.
+func TestSplitPath(t *testing.T) {
+	tests := []struct {
+		ref       string
+		wantSvc   string
+		wantField string
+		wantErr   bool
+	}{
+		{ref: "github", wantSvc: "github", wantField: ""},
+		{ref: "postgres:username", wantSvc: "postgres", wantField: "username"},
+		{ref: "postgres/username", wantSvc: "postgres", wantField: "username"},
+		{ref: "my:svc/password", wantSvc: "my:svc", wantField: "password"}, // colon literal in slash mode
+		{ref: "svc/", wantErr: true},
+		{ref: "/field", wantErr: true},
+		{ref: "vault/svc/field", wantErr: true}, // 3+ segments reserved
+		{ref: "svc:", wantErr: true},
+		{ref: ":field", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			svc, field, err := SplitPath(tt.ref)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got service=%q field=%q", svc, field)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if svc != tt.wantSvc || field != tt.wantField {
+				t.Errorf("SplitPath(%q) = (%q, %q), want (%q, %q)", tt.ref, svc, field, tt.wantSvc, tt.wantField)
 			}
 		})
 	}

--- a/internal/envmap/envmap_test.go
+++ b/internal/envmap/envmap_test.go
@@ -1,0 +1,65 @@
+package envmap
+
+import "testing"
+
+// TestDeriveEnvName verifies service -> env var name derivation.
+func TestDeriveEnvName(t *testing.T) {
+	tests := []struct {
+		service string
+		want    string
+	}{
+		{"openai-api", "OPENAI_API"},
+		{"github", "GITHUB"},
+		{"aws.prod", "AWS_PROD"},
+		{"my service", "MY_SERVICE"},
+		{"api/v2:key", "API_V2_KEY"},
+		{"already_ok", "ALREADY_OK"},
+		{"GH123", "GH123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.service, func(t *testing.T) {
+			if got := DeriveEnvName(tt.service); got != tt.want {
+				t.Errorf("DeriveEnvName(%q) = %q, want %q", tt.service, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseSetSpec covers the per-spec grammar: NAME=service, the ':field'
+// override, and every error path. This is the colon grammar extracted verbatim
+// from cmd/exec.go in Phase 0a; the slash form is added in 0b.
+func TestParseSetSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		want    Mapping
+		wantErr bool
+	}{
+		{name: "service only", spec: "GITHUB_TOKEN=github", want: Mapping{"GITHUB_TOKEN", "github", ""}},
+		{name: "field override", spec: "DB_USER=postgres:username", want: Mapping{"DB_USER", "postgres", "username"}},
+		{name: "empty field after colon", spec: "K=svc:", wantErr: true},
+		{name: "empty service before colon", spec: "K=:username", wantErr: true},
+		{name: "no equals", spec: "NOEQUALS", wantErr: true},
+		{name: "empty service", spec: "K=", wantErr: true},
+		{name: "empty name", spec: "=github", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSetSpec(tt.spec)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseSetSpec(%q) = %+v, want %+v", tt.spec, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1,0 +1,81 @@
+// Package resolver materializes credential mappings into "NAME=value" env entries.
+//
+// It is the substrate shared by every injection surface (exec today; export, run,
+// and inject later). A Resolver has two interchangeable backends: directResolver,
+// which reads an already-unlocked in-process vault, and — once the agent exists —
+// a socket backend that asks a resident daemon. Consumers try the socket and fall
+// back to direct-open, so the daemon is a transparent optimization.
+//
+// Resolve is read-only by contract: it never records field access and never
+// triggers a sync push, preserving exec's deliberate no-write semantics for every
+// consumer.
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/arimxyer/pass-cli/internal/crypto"
+	"github.com/arimxyer/pass-cli/internal/envmap"
+	"github.com/arimxyer/pass-cli/internal/vault"
+)
+
+// Resolver materializes credential mappings into "NAME=value" strings.
+type Resolver interface {
+	// Resolve turns each mapping into "NAME=value". A mapping with an empty Field
+	// falls back to defaultField. It is read-only: no usage tracking, no sync push.
+	Resolve(mappings []envmap.Mapping, defaultField string) ([]string, error)
+	// Close releases any backend resources. For the direct backend the caller owns
+	// the vault's lifecycle, so Close is a no-op.
+	Close() error
+}
+
+// directResolver resolves against an already-unlocked, in-process VaultService.
+// The caller owns unlock/Lock; this type only reads.
+type directResolver struct {
+	vs *vault.VaultService
+}
+
+// NewDirect returns a Resolver backed by an already-unlocked vault. The caller
+// remains responsible for locking the vault when done.
+func NewDirect(vs *vault.VaultService) Resolver {
+	return &directResolver{vs: vs}
+}
+
+func (d *directResolver) Resolve(mappings []envmap.Mapping, defaultField string) ([]string, error) {
+	out := make([]string, 0, len(mappings))
+	for _, m := range mappings {
+		// A per-mapping field (service:field) overrides the caller's default field.
+		field := m.Field
+		if field == "" {
+			field = defaultField
+		}
+		entry, err := buildEnvEntry(d.vs, m, field)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+// Close is a no-op: the direct backend does not own the vault.
+func (d *directResolver) Close() error { return nil }
+
+// buildEnvEntry fetches one credential, resolves the requested field, and returns
+// the "NAME=value" string. The credential's secret bytes are cleared before the
+// function returns; the field value is read first, so the wiped bytes never affect
+// the returned string.
+func buildEnvEntry(vs *vault.VaultService, m envmap.Mapping, field string) (string, error) {
+	// GetCredential returns a deep copy, so clearing Password does not touch the vault.
+	cred, err := vs.GetCredential(m.Service, false)
+	if err != nil {
+		return "", fmt.Errorf("failed to get credential %q: %w", m.Service, err)
+	}
+	defer crypto.ClearBytes(cred.Password)
+
+	value, _, err := vault.ResolveCredentialField(cred, field)
+	if err != nil {
+		return "", err
+	}
+	return m.EnvName + "=" + value, nil
+}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1,0 +1,136 @@
+package resolver
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arimxyer/pass-cli/internal/envmap"
+	"github.com/arimxyer/pass-cli/internal/vault"
+)
+
+// newUnlockedVault creates a temp vault with a single "github" credential and
+// returns the unlocked service plus its file path. useKeychain=false keeps it off
+// the OS keyring so it runs in CI.
+func newUnlockedVault(t *testing.T) (*vault.VaultService, string) {
+	t.Helper()
+	dir := t.TempDir()
+	vaultPath := filepath.Join(dir, "vault.enc")
+	auditPath := filepath.Join(dir, "audit.log")
+
+	vs, err := vault.New(vaultPath)
+	if err != nil {
+		t.Fatalf("vault.New: %v", err)
+	}
+	// Initialize clears the password bytes, so Unlock gets its own copy.
+	if err := vs.Initialize([]byte("TestPassword123!"), false, auditPath, "test-vault-id"); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := vs.Unlock([]byte("TestPassword123!")); err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	if err := vs.AddCredential("github", "octocat", []byte("s3cr3t-pw"), "vcs", "https://github.com", "note"); err != nil {
+		t.Fatalf("AddCredential: %v", err)
+	}
+	return vs, vaultPath
+}
+
+// TestDirectResolver_ResolvesFields covers the default field, a per-mapping field
+// override, and the "NAME=value" shape.
+func TestDirectResolver_ResolvesFields(t *testing.T) {
+	vs, _ := newUnlockedVault(t)
+	defer vs.Lock()
+
+	r := NewDirect(vs)
+	defer func() { _ = r.Close() }()
+
+	got, err := r.Resolve([]envmap.Mapping{
+		{EnvName: "GITHUB_TOKEN", Service: "github"},               // default field
+		{EnvName: "GH_USER", Service: "github", Field: "username"}, // per-mapping override
+	}, "password")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	want := []string{"GITHUB_TOKEN=s3cr3t-pw", "GH_USER=octocat"}
+	if len(got) != len(want) {
+		t.Fatalf("Resolve returned %d entries, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestDirectResolver_DefaultFieldFallback verifies the defaultField argument is
+// applied when a mapping has no per-mapping field.
+func TestDirectResolver_DefaultFieldFallback(t *testing.T) {
+	vs, _ := newUnlockedVault(t)
+	defer vs.Lock()
+
+	r := NewDirect(vs)
+	defer func() { _ = r.Close() }()
+
+	got, err := r.Resolve([]envmap.Mapping{{EnvName: "GH", Service: "github"}}, "username")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) != 1 || got[0] != "GH=octocat" {
+		t.Errorf("got %v, want [GH=octocat]", got)
+	}
+}
+
+// TestDirectResolver_ReadOnly_DoesNotMutateVault is the load-bearing guarantee:
+// resolving must never write the vault file. A write would change the vault hash
+// and trigger a sync push on the hot path — exactly the slowness #120 removed.
+func TestDirectResolver_ReadOnly_DoesNotMutateVault(t *testing.T) {
+	vs, vaultPath := newUnlockedVault(t)
+	defer vs.Lock()
+
+	before, err := os.ReadFile(vaultPath)
+	if err != nil {
+		t.Fatalf("read vault before: %v", err)
+	}
+
+	r := NewDirect(vs)
+	defer func() { _ = r.Close() }()
+	if _, err := r.Resolve([]envmap.Mapping{{EnvName: "GH", Service: "github"}}, "password"); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	after, err := os.ReadFile(vaultPath)
+	if err != nil {
+		t.Fatalf("read vault after: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("Resolve mutated the vault file; the resolve path must be strictly read-only")
+	}
+}
+
+// TestDirectResolver_UnknownService surfaces the vault error for a missing service.
+func TestDirectResolver_UnknownService(t *testing.T) {
+	vs, _ := newUnlockedVault(t)
+	defer vs.Lock()
+
+	r := NewDirect(vs)
+	defer func() { _ = r.Close() }()
+
+	if _, err := r.Resolve([]envmap.Mapping{{EnvName: "X", Service: "nonexistent"}}, "password"); err == nil {
+		t.Fatal("expected error for unknown service, got nil")
+	}
+}
+
+// TestDirectResolver_InvalidField surfaces the field-resolver error.
+func TestDirectResolver_InvalidField(t *testing.T) {
+	vs, _ := newUnlockedVault(t)
+	defer vs.Lock()
+
+	r := NewDirect(vs)
+	defer func() { _ = r.Close() }()
+
+	if _, err := r.Resolve([]envmap.Mapping{{EnvName: "X", Service: "github", Field: "totp"}}, "password"); err == nil {
+		t.Fatal("expected error for invalid field, got nil")
+	}
+}

--- a/internal/vault/field.go
+++ b/internal/vault/field.go
@@ -1,0 +1,33 @@
+package vault
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ResolveCredentialField returns the requested field's value from a credential
+// along with its canonical name (for usage tracking). It is the single source of
+// truth for the field aliases accepted by `get` and `exec`, keeping the valid-field
+// list from drifting between the two commands.
+//
+// Security note: for the password field this returns string(cred.Password); the
+// caller is responsible for clearing the source []byte (crypto.ClearBytes) and for
+// never printing or copying the value where the brief forbids it.
+func ResolveCredentialField(cred *Credential, field string) (value string, canonical string, err error) {
+	switch strings.ToLower(field) {
+	case "username", "user", "u":
+		return cred.Username, "username", nil
+	case "password", "pass", "p":
+		return string(cred.Password), "password", nil
+	case "category", "cat", "c":
+		return cred.Category, "category", nil
+	case "url":
+		return cred.URL, "url", nil
+	case "notes", "note", "n":
+		return cred.Notes, "notes", nil
+	case "service", "s":
+		return cred.Service, "service", nil
+	default:
+		return "", "", fmt.Errorf("invalid field: %s (valid: username, password, category, url, notes, service)", field)
+	}
+}

--- a/internal/vault/field_test.go
+++ b/internal/vault/field_test.go
@@ -1,0 +1,61 @@
+package vault
+
+import "testing"
+
+// TestResolveCredentialField verifies the shared field resolver covers every alias
+// used by both `get` and `exec`, returns the canonical name, and rejects bad fields.
+func TestResolveCredentialField(t *testing.T) {
+	cred := &Credential{
+		Service:  "github",
+		Username: "octocat",
+		Password: []byte("s3cr3t-pw"),
+		Category: "vcs",
+		URL:      "https://github.com",
+		Notes:    "personal token",
+	}
+
+	tests := []struct {
+		field         string
+		wantValue     string
+		wantCanonical string
+	}{
+		{"username", "octocat", "username"},
+		{"user", "octocat", "username"},
+		{"u", "octocat", "username"},
+		{"password", "s3cr3t-pw", "password"},
+		{"pass", "s3cr3t-pw", "password"},
+		{"p", "s3cr3t-pw", "password"},
+		{"PASSWORD", "s3cr3t-pw", "password"}, // case-insensitive
+		{"category", "vcs", "category"},
+		{"cat", "vcs", "category"},
+		{"c", "vcs", "category"},
+		{"url", "https://github.com", "url"},
+		{"notes", "personal token", "notes"},
+		{"note", "personal token", "notes"},
+		{"n", "personal token", "notes"},
+		{"service", "github", "service"},
+		{"s", "github", "service"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			value, canonical, err := ResolveCredentialField(cred, tt.field)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if value != tt.wantValue {
+				t.Errorf("value = %q, want %q", value, tt.wantValue)
+			}
+			if canonical != tt.wantCanonical {
+				t.Errorf("canonical = %q, want %q", canonical, tt.wantCanonical)
+			}
+		})
+	}
+
+	t.Run("invalid field", func(t *testing.T) {
+		_, _, err := ResolveCredentialField(cred, "totp")
+		if err == nil {
+			t.Fatal("expected error for invalid field, got nil")
+		}
+	})
+}

--- a/plans/2026-06-30-daemon-and-env-injection-plan.md
+++ b/plans/2026-06-30-daemon-and-env-injection-plan.md
@@ -1,0 +1,244 @@
+# Design: Background Agent (#116) + Env-Injection Ergonomics (#115)
+
+> Status: design / plan. Tracks GitHub issues #115 (ergonomics) and #116 (agent/daemon substrate).
+> Phase 0 in progress; Phases 1–3 not yet written against.
+
+## Decisions baked in (2026-07-01)
+
+Five steers from the owner, resolved into this plan:
+
+1. **Grammar: slash-delimited path separator, added *additively*.** `/` becomes the preferred separator (`service/field`); the shipped `:` form keeps working unchanged as a back-compat alias — **no deprecation warning, no removal.** The colon isn't broken today (one colon, fixed field set), so this is *forward-consistency* (users learn one separator for `--set`, templates, and the manifest) and `op://` alignment, not a bug fix. This is the "first peg" set in Phase 0 so every later surface (templates §4, socket protocol §5) inherits the same separator. See §3.1 for the exact parse rule.
+2. **Broader usage tracking is OK, but never on the sync-speed critical path.** Tracking writes must be *batched / deferred*, never a per-access sync push (that was the #120 slowness). See §5.5.
+3. **The daemon holds an in-memory vault snapshot; concurrent CLI operations must still work.** No exclusive file lock — other processes read/write `vault.enc` freely. The daemon runs a *revalidating cache*: it detects an on-disk change via the #102/#120 content-hash marker and refreshes its snapshot rather than serving stale data or locking others out. See §5.8.
+4. **memguard: approved.** Confined to the agent package; the one-shot CLI keeps `crypto.ClearBytes`. See §5.6.
+5. **This session coordinates the implementation** (may fan out to subagents), building Phase 0 first.
+
+Scope discipline: **only decision #1 touches Phase 0.** #2/#3/#4 are all Phase 2 (the daemon) — recorded here as text, not built in the first pass. If Phase-0 code starts looking daemon-adjacent, that's drift.
+
+## 0. Framing — the substrate is a `Resolver`, not the daemon
+
+The unifying abstraction is **not** "the daemon." It is a single interface that turns the existing `--set ENV=service[:field]` mappings into materialized `NAME=value` strings, with two interchangeable backends:
+
+```go
+type Resolver interface {
+    // Resolve materializes each mapping into "NAME=value".
+    // Read-only: it never records usage and never triggers a sync push.
+    Resolve(mappings []envMapping, defaultField string) ([]string, error)
+    Close() error
+}
+```
+
+- **`directResolver`** — today's path: `vault.New` → `unlockVaultWithSync` → `buildEnvEntry` per mapping → `Lock()`. This already exists inside `cmd/exec.go`; Phase 0 extracts it.
+- **`socketResolver`** — dials the agent, sends the mappings, receives the values. The agent already holds an unlocked `VaultService`, so there is no per-call PBKDF2 and no prompt.
+
+Every consuming command (`exec`, `export`, `run`/`inject`, and optionally `get`) does the same thing: **try the socket, fall back to direct-open.** This makes the daemon a transparent optimization (satisfying #116's "daemon is not a hard dependency") and directly answers the "what can ship incrementally" question: the #115 surfaces (`export`, `inject`, manifest) ship on `directResolver` **before** the daemon exists, then transparently accelerate once the socket backend lands.
+
+The sequencing is therefore **not** "#116 then #115." It is:
+
+1. **Phase 0** — extract the shared resolver + grammar (no behavior change).
+2. **Phase 1** — #115 surfaces on `directResolver` (`export`, `inject`/template, `.pass-cli.toml` manifest).
+3. **Phase 2** — #116 agent: daemon process + IPC + `socketResolver`, auto-detected by the Phase-1 surfaces.
+4. **Phase 3** — lifecycle hardening (auto-lock, locked memory, peer-cred per platform) and optional platform service units.
+
+---
+
+## 1. Current-state facts the plan is built on
+
+| Concern | Where | Note |
+|---|---|---|
+| Mapping grammar `ENV=service[:field]` | `cmd/exec.go` `parseExecArgs`, `envMapping`, `deriveEnvName` | Pure parsing, already unit-testable. Move to a shared package. |
+| Materialize one field | `cmd/exec.go` `buildEnvEntry` + `cmd/helpers.go` `resolveCredentialField` | `resolveCredentialField` is the single source of truth for field aliases shared by `get`/`exec`. Reuse verbatim. |
+| Entry-point unlock | `cmd/helpers.go` `unlockVaultWithSync` | Overlaps sync pull with the password prompt (#103). The daemon calls this **once** at unlock. |
+| In-memory unlocked state | `internal/vault/vault.go` `VaultService` (`masterPassword []byte`, `vaultData`, `unlocked`) | This whole object is what the daemon holds resident. `GetCredential` returns a deep copy; `Lock()` zeros secrets via `crypto.ClearBytes`. **Not concurrency-safe for mutation.** |
+| Key handling today | `crypto.ClearBytes` zeroing; no `mlock`, no core-dump suppression | New capability for the daemon. |
+| Keychain unlock | `vault.RetrieveKeychainPassword` / `UnlockWithKeychain` via `internal/keychain` (zalando/go-keyring) | Reads keyring without decrypting vault.enc. macOS keychain is session-bound (the test HOME trap). |
+| `exec` is deliberately read-only | `cmd/exec.go` comment at `runExec` | No `RecordFieldAccess`, no `syncPushAfterCommand`. The resolver must preserve this. |
+| No platform-specific files exist | `find` for `*_linux.go` etc. → none | The daemon introduces the build-tag pattern for the first time. |
+| Test split | `internal/*_test.go` (no tag, unit) vs `test/integration/*` (`//go:build integration`, drives the built binary via `helpers.RunCmd`) | macOS HOME-override trap guarded by `runtime.GOOS == "darwin"` in `test/helpers/command.go:121-129`. |
+
+---
+
+## 2. Security model (state as invariants, do not oversell)
+
+1. **The daemon serves resolved field values only. It never returns the master password or the derived key over the socket.** This is the ssh-agent property and the core invariant. A compromised client gets the secrets it was already going to inject — nothing more durable.
+2. **The materialization ceiling (#115) is unchanged.** A consumer that reads `process.env` forces plaintext to exist at the boundary. The agent changes *who holds the long-lived key and for how long*, not whether plaintext must materialize.
+3. **Same ceiling as ssh-agent/gpg-agent, stated per-platform — not a blanket "no protection":**
+   - **Linux:** `mlock` (no swap) + `prctl(PR_SET_DUMPABLE, 0)` (no core dump, blocks casual same-user `/proc/<pid>/mem` and ptrace attach by non-root) is real hardening. The honest ceiling: **root, or a same-user process that can still ptrace, can read daemon memory.** Strictly better than a long-lived shell env var or a plaintext `.env`.
+   - **macOS:** locked memory via memguard; task_for_pid is gated, but same-user with the right entitlements/SIP-off can read. Document parity with gpg-agent.
+   - **Windows:** named-pipe ACL restricts the pipe to the owning SID; process memory is readable by same-user debuggers. Document parity.
+4. **Never log values.** The protocol carries secrets; the daemon's logger must be structurally incapable of emitting a value (log mapping *names* and *service* keys only, never resolved bytes). Add a test that greps daemon stderr for a known secret and fails if found.
+
+---
+
+## 3. Phase 0 — extract the shared resolver + the slash "first peg"
+
+Phase 0 ships as **two isolated commits** so the regression gate stays unambiguous — if a test goes red, exactly one change is implicated:
+
+- **0a — pure extraction, zero behavior change.** Move `envMapping`, `parseExecArgs`, `deriveEnvName` from `cmd/exec.go` into a new pure package `internal/envmap` (no I/O). Add `internal/resolver` with the `Resolver` interface and `directResolver` (lifts `buildEnvEntry`'s body, reusing `resolveCredentialField`, preserving read-only semantics). `cmd/exec.go` becomes a thin client: parse → pick a resolver → `Resolve` → `runChild`. The **existing exec integration + unit tests pass unchanged** — that is the 0a gate. No grammar change in this commit.
+- **0b — additive slash parsing + new slash tests.** Teach the extracted parser the slash rule (§3.1) *without* touching the colon path. New slash-input tests; the colon tests from 0a stay green as the back-compat proof.
+
+### 3.1 The slash parse rule (decision #1)
+
+Applied uniformly wherever a `service[/field]` spec is parsed (`--set` value, later the manifest and template refs):
+
+- **Separator is picked by presence; slash wins.**
+  - If the spec contains `/` → slash mode: split into segments on `/`. Require **exactly two** (`service/field`) for now; **3+ segments error** with "multi-segment paths not yet supported" — this reserves `vault/service/field` (field = last segment, `op://`-compatible) for a future multi-vault without designing vaults today. In slash mode **any `:` is a literal character** — this is the actual fragility fix: colons in service names or composite values stop being separators.
+  - Else if the spec contains `:` → legacy mode: **byte-for-byte the current behavior** — `strings.Cut` on the *first* colon, service before, field after. Do **not** "improve" it to last-colon; that would silently change existing colon users.
+  - Else (no separator) → whole spec is the service, field falls back to the global `--field` / default.
+- **No deprecation warning on colon.** "Alias" means "still works, docs prefer slash." Output is unchanged for colon users.
+- Template refs (§4) and the manifest (§4.3) are greenfield → slash-only from day one; `op://vault/item/field` reserved as a later alias (decision #1 keeps op-style on the table for multi-vault).
+
+**Risk:** 0a is a mechanical refactor gated by the existing exec suite. 0b is additive and gated by keeping the colon tests unchanged; no shipped behavior is removed.
+
+---
+
+## 4. Phase 1 — #115 surfaces on direct-open (ship before the daemon)
+
+Keep #115's own ranking: **1/2/4 are real (persistence, ceremony, source-of-truth); 3 (transforms) is a band-aid.**
+
+### 4.1 `pass-cli export` (#115.1) — ranked #1
+New `cmd/export.go`. Reuses the mapping grammar. Emits shell-quoted `export NAME='value'` to stdout for `eval`/direnv.
+- **Quoting:** single-quote with `'\''` escaping (POSIX). Add `--format {sh,fish,powershell}` (fish: `set -gx NAME value`; pwsh: `$env:NAME='value'`). Default `sh`.
+- **direnv:** ship a stdlib snippet `use pass_cli <args>` that wraps `eval "$(pass-cli export ...)"` in docs; no code dependency on direnv.
+- **Honest caveat (documented):** `export` materializes into the *current* shell for that shell's lifetime — weaker than `exec`'s child-scoped injection. The doc must say: prefer `exec`/`run` when you only need to launch a command; `export` is the blessed alternative to `VAR="$(pass-cli get …)"`, not to `exec`.
+
+### 4.2 `pass-cli run --env-file <template>` / `pass-cli inject` (#115.2) — ranked #2
+A committable template with **references only** is resolved in-memory.
+- `inject`: read template from stdin/file, write resolved text to stdout (op-inject analogue) — solves composite/derived secrets like `postgres://user:${pass:db:password}@host`.
+- `run --env-file <tmpl> -- <cmd>`: resolve the template into the child env (never to disk), then `runChild`. This is the child-scoped materialization the issue prioritizes.
+
+### 4.3 Project manifest `.pass-cli.toml` / `--from <file>` (#115.4) — ranked #4
+Names-only map so launchers/`.envrc` don't repeat long `--set` chains:
+```toml
+[env]
+GITHUB_TOKEN = "github:password"
+DB_PASSWORD  = "postgres:password"
+```
+`--from .pass-cli.toml` expands to the same `[]envMapping`. Parser lives in `internal/envmap`. Committable because it contains **references, never values**.
+
+### 4.4 Transforms (#115.3) — band-aid, deferred
+Do **not** build a general filter pipeline now. If pressure exists, scope to a single, explicitly-labeled-convenience `:base64` suffix for Basic-auth headers, gated behind a follow-up. Present it as a band-aid, not a peer feature.
+
+### 4.5 Reference syntax — `${pass:service/field}` (slash path, decision #1)
+**Native `${pass:service/field}`** — the `pass:` scheme prefix plus the slash path from §3.1. `op://vault/item/field` reserved as a later alias for 1Password migrators.
+Why slash and not `${pass:service:field}`: the template is exactly where the colon bites — a scheme colon *plus* a separator colon, nested inside URIs full of their own colons (`postgres://u:${pass:db/password}@h`). Slash makes the inner colons literal (§3.1) and lines up with `op://…/…/…` so a future multi-vault segment prepends cleanly (`${pass:vault/service/field}`). The discriminator still holds — pass-cli binds **one vault per invocation** (`GetVaultPath`), so the leading vault segment stays absent until multi-vault exists; the two-segment `service/field` is the only accepted shape for now (§3.1's "3+ segments error").
+
+---
+
+## 5. Phase 2 — the agent (#116) and the socket backend
+
+### 5.1 Process & commands
+New `cmd/agent.go` group:
+- `pass-cli agent` — start (foreground by default; `--daemonize` to background). Unlocks once via `unlockVaultWithSync`, then serves.
+- `pass-cli agent stop` — graceful shutdown (sends a shutdown request or signals the pid).
+- `pass-cli agent status` — running? idle time? max-TTL remaining? (never prints secrets).
+- `pass-cli lock` — re-lock the agent's vault without killing the process.
+
+### 5.2 IPC: framed request/response over a local stream
+- **Transport:** `net` Unix-domain stream socket on POSIX; **named pipe on Windows** via `github.com/Microsoft/go-winio` (`winio.ListenPipe`). Abstract behind a small `agentconn` package with build-tagged listener/dialer.
+- **Wire format:** newline-delimited JSON or length-prefixed JSON frames. JSON is fine — values are short and the channel is local; readability aids the "never log values" audit. **One method matters:** `resolve(mappings, defaultField) -> [{name, value}] | error`. Plus `lock`, `status`, `shutdown`. Explicitly **no** `get-master-password` / `get-key` method exists in the protocol (invariant #1).
+- **Protocol versioning:** include a `version` field; the client falls back to direct-open on version mismatch rather than erroring.
+
+### 5.3 Socket location & lifecycle hygiene
+- **Linux:** `$XDG_RUNTIME_DIR/pass-cli/agent.sock` (tmpfs, auto-cleared on logout → doubles as logout-lock). Fallback `~/.pass-cli/agent.sock`, dir `0700`, socket `0600`.
+- **macOS:** `~/.pass-cli/agent.sock` (or `$TMPDIR`), `0600`.
+- **Windows:** `\\.\pipe\pass-cli-<SID>` with an ACL granting only the owning SID.
+- **Stale-socket reclaim on startup:** dial the existing path; if connection refused, `unlink` + rebind; if it answers, exit "agent already running." (Classic footgun — make it explicit.)
+- **Discovery by clients:** env var `PASS_CLI_AGENT_SOCK` overrides; else the default path. If dialing fails for any reason, fall back to direct-open silently (verbose: note the fallback on stderr).
+
+### 5.4 Auth: peer-credential checks in build-tagged files
+New files (introducing the platform-file pattern this repo lacks today):
+- `agentconn/peercred_linux.go` — `SO_PEERCRED` (`unix.GetsockoptUcred`), assert `uid == os.Getuid()`.
+- `agentconn/peercred_darwin.go` — `getpeereid` (via `golang.org/x/sys/unix`), assert uid.
+- `agentconn/peercred_windows.go` — `GetNamedPipeClientProcessId` + token/SID comparison; the primary control is the pipe ACL. **Verify the exact go-winio / `x/sys/windows` API at implementation time** (go-winio was not resolvable in the docs index during planning; confirm it surfaces client PID/SID).
+Reject any peer whose uid/SID ≠ the agent owner, **before** processing the request.
+
+### 5.5 Concurrency: mutex-guarded, read-only resolve
+`VaultService` is not safe for concurrent mutation. The agent serves N shells:
+- Wrap the resident `VaultService` in a `sync.Mutex` (or RWMutex with resolve under RLock).
+- Resolve path stays **read-only** (no `RecordFieldAccess`, no save) — same discipline as `exec` today, now enforced for all clients.
+- **Usage tracking must never sit on the sync-speed critical path (decision #2).** Today `get` writes a usage timestamp → changes the vault hash → triggers a sync push → the exact slowness #120 fought. The owner wants *broader* tracking without paying that cost, so tracking is **batched/deferred, never a per-access push**:
+  - **Daemon path (natural fit):** the resident agent accumulates `(service, field, ts)` access events in memory and flushes them into the vault **coalesced** — on idle, on `lock`, or on a bounded interval — as a single write+push, not one per access. Add an explicit fire-and-forget `track(service, field)` RPC (client does not block on it). The socket path can therefore keep tracking *and* stay fast, so `get`-over-socket is viable once the daemon exists.
+  - **One-shot CLI path:** tracking stays local and lazy — record the access, but let the existing TTL-gate / dirty-flag (#120) defer or coalesce the push rather than forcing a round-trip per `get`. Never re-introduce a synchronous push on the hot path.
+  - **First cut, no daemon:** `get` stays direct-open with today's (already deferred) local write. The `track` RPC and cross-command batching land with the daemon.
+
+### 5.6 Key handling in memory
+- **Decided (decision #4): memguard**, confined to the agent package. Hold the derived key / master password as an `Enclave` at rest (encrypted, not mlock-limited), `Open()` into a `LockedBuffer` only for the duration of a resolve, then `Destroy()`. memguard already does mlock + core-dump handling + a catch-signals/purge path — correctness of mlock/guard-pages by hand is easy to get wrong, so we take the dependency here.
+- **Confinement:** the one-shot CLI keeps its existing `crypto.ClearBytes` path unchanged; memguard touches only the agent package, so the rest of the binary and its footprint are unaffected. Reshaping how the daemon's resident `VaultService` stores `masterPassword` is expected and scoped to that package.
+
+### 5.7 Auto-lock & lifecycle
+- **Idle timeout** (`--idle 15m`, configurable): reset on each resolve; on expiry call `VaultService.Lock()` but keep the process alive, re-prompt/keychain-unlock on next request — or refuse and require `pass-cli agent` re-unlock (recommend: refuse and require explicit re-unlock; auto-reprompt from a daemon is awkward without a controlling TTY).
+- **Max-TTL re-lock** (`--max-ttl 8h`): hard cap regardless of activity.
+- **Signals:** SIGTERM/SIGINT → lock + clean socket unlink + exit. Trap so secrets are zeroed on shutdown.
+- **Suspend/logout:** rely on `$XDG_RUNTIME_DIR` clearing (Linux) and idle/max-TTL elsewhere; document that suspend does not auto-lock (same as ssh-agent) — set a short idle timeout if that matters.
+- **Multi-shell:** one agent per user session serves all shells via the shared socket. Document that re-running `pass-cli agent` attaches to the existing one rather than starting a second.
+
+### 5.8 Daemon snapshot + revalidating cache (decision #3)
+The daemon holds an **in-memory vault snapshot** and must **not** take an exclusive lock on `vault.enc` — concurrent CLI processes (`add`/`update`/`get` from another shell) keep reading and writing the file freely. That means two independent staleness axes:
+
+- **vs. the local file** (a sibling CLI process wrote the vault): the daemon runs a **revalidating cache**. Before serving a resolve, it cheaply checks whether `vault.enc` changed on disk since the snapshot was taken — reuse the #102/#120 content-hash marker (or mtime/size fallback), the same machinery `SmartPull` already reads, so it's a local stat, not a network call. On change: **refresh the snapshot** (re-read + re-decrypt with the resident key) rather than serving stale bytes. This is what keeps "other operations continue" coherent — the daemon yields to on-disk writers instead of fighting them.
+- **vs. the remote** (someone pushed from another machine): the daemon pulls at unlock and serves that snapshot; remote changes are not seen until the next unlock/`lock`+unlock. Optional TTL-bounded background re-pull (`--sync-refresh 5m`) later. The #103 overlap code is one-shot-command-shaped and must not be assumed to keep a daemon fresh.
+
+**Write coherence:** if the batched usage tracking (§5.5) flushes while a sibling CLI process has rewritten the vault, the daemon must re-read-modify-write against the current on-disk file (the revalidate step above), never blind-overwrite from a stale snapshot — same conflict-safety discipline as the sync layer.
+
+### 5.9 Keychain unlock from the daemon (macOS trap)
+The agent unlocks via master-password prompt **or** `UnlockWithKeychain`. On macOS, keychain access is bound to the user session — so the daemon must run in the real session with real `HOME`/`USER`/`TMPDIR`. This is exactly the constraint the test helper already encodes; the daemon's spawn path (and its tests) must not fake `HOME` on darwin.
+
+---
+
+## 6. Phase 3 — optional platform service
+
+Pure run-on-demand first (user runs `pass-cli agent`). Then optionally ship templates (not auto-installed):
+- **Linux:** `systemd --user` unit + socket activation (`pass-cli-agent.socket` → tmpfs path; systemd hands the listener fd, which also gives clean logout teardown).
+- **macOS:** a `launchd` LaunchAgent plist.
+- **Windows:** a user-session service or scheduled-task-at-logon wrapper.
+
+**Recommendation:** ship run-on-demand + documented unit templates; do not auto-register a service (surprising for a security tool). Socket activation is a nice-to-have, not Phase-2 critical.
+
+---
+
+## 7. Testing strategy (fit the unit/integration split)
+
+### 7.1 Unit (`internal/`, no build tag) — most logic lives here
+- `internal/envmap`: `parseExecArgs`, `deriveEnvName`, `.pass-cli.toml` parsing, `${pass:service:field}` template parsing incl. malformed/escaped/composite cases.
+- `internal/resolver`: `directResolver` against an in-memory/temp vault; assert read-only (no usage write, no sync push).
+- Agent internals with **no live socket**: auto-lock timer with an **injected clock** (no real sleeps), max-TTL, peer-cred parsing (table-driven over fake ucred/SID), protocol marshal/unmarshal round-trips, and a "logger never emits a known secret" test. Keep the listener thin so the bulk is testable without binding a socket.
+
+### 7.2 Integration (`test/integration/`, `//go:build integration`, drives the built binary)
+New `agent_test.go` + `export_test.go` + `inject_test.go`:
+- Add an agent spawn helper modeled on `helpers.RunCmd` that starts `pass-cli agent` as a background process on a temp socket + temp config, waits for the socket, runs `exec`/`export` against it, and asserts (a) the socket was actually used (e.g., agent log/status shows a resolve, or kill-the-agent-and-confirm-fallback), and (b) **fallback to direct-open when the agent is absent** produces identical output.
+- **macOS guard:** the spawn helper must pass `HOME`/`USER`/`TMPDIR` through on darwin exactly like `RunCmdWithEnv` (`command.go:121-129`); keychain-via-daemon tests use the `runtime.GOOS != "darwin"` guard before any fake-HOME setup.
+- **Windows:** named-pipe path needs its own `runtime.GOOS == "windows"`-targeted tests; the existing POSIX-sh tests already `t.Skip` on Windows — mirror that for the socket tests and add pipe-specific coverage.
+- `export`/`inject` integration tests can run **without** the agent first (direct-open), proving the incremental-ship claim, then re-run with the agent up.
+
+---
+
+## 8. Risks, dependencies, sequencing
+
+- **Phase 0 is a pure refactor** gated by the existing exec suite — low risk, do it first.
+- **#115 ships independently of #116** on `directResolver`. `export` could ship in the very next release with the documented "current-shell lifetime" caveat.
+- **Concurrency:** `VaultService` mutation is not thread-safe; the mutex + read-only-resolve discipline is mandatory, and `get`-over-socket's tracking divergence must be a conscious decision (recommend: `get` stays direct-open).
+- **Sync staleness** is the only behavioral regression versus today's per-command pull — document, optionally TTL-refresh.
+- **Cross-platform peer-cred** introduces the repo's first build-tagged platform files; budget for three implementations + the Windows ACL. Verify go-winio's client-identity API at implementation time.
+- **memguard** is a new dependency confined to the agent; keep `crypto.ClearBytes` for one-shot commands so the CLI surface is unchanged.
+- **macOS keychain session binding** constrains both the daemon runtime and its tests (no fake HOME on darwin).
+
+---
+
+## Top 5 design recommendations
+
+1. **Make a `Resolver` interface the substrate, not the daemon.** Both backends implement it; all injection commands try-socket-then-fall-back. This makes #115 shippable before #116 exists and the daemon a true optional optimization.
+2. **The agent serves resolved field values only — never the master password or derived key over the wire.** State this as the core security invariant; the protocol has no key-export method by construction. Honest ceiling = same as ssh-agent (root/ptrace can read memory), with `mlock`+`PR_SET_DUMPABLE=0` as real, per-platform hardening — not a blanket claim.
+3. **Slash is the "first peg" (decision #1): `service/field` native, `:` kept as a silent back-compat alias, `op://` reserved for future multi-vault.** Set it in Phase 0 (additively, no breakage) so `--set`, the manifest, and `${pass:service/field}` templates all share one separator; slash makes inner colons literal, which is the real fragility fix.
+4. **Guard the resident vault with a mutex and keep the resolve path read-only, but batch usage tracking off the critical path (decision #2).** `VaultService` isn't concurrency-safe; preserve `exec`'s no-push discipline. Tracking is a fire-and-forget `track` RPC coalesced into one deferred write — never a per-access push — so `get`-over-socket keeps tracking *and* stays fast once the daemon exists; first cut keeps `get` direct-open.
+5. **Daemon = revalidating cache, not a lock holder (decision #3).** It serves an in-memory snapshot, takes no exclusive file lock, and refreshes from disk via the #102/#120 content-hash marker when a sibling CLI process writes — so concurrent operations continue. Remote staleness is the one deliberate semantic change (snapshot from unlock-time; optional TTL re-pull). Respect the macOS keychain session-binding trap in daemon runtime + spawn-helper tests (no fake `HOME` on darwin), with Windows named-pipe + ACL peer-auth as a separate path. memguard (decision #4) confined to the agent package.
+
+---
+
+## Critical files for implementation
+
+- `cmd/exec.go` — grammar `parseExecArgs`/`envMapping`/`buildEnvEntry` to extract; becomes a thin resolver client.
+- `cmd/helpers.go` — `resolveCredentialField`, `unlockVaultWithSync` — reused by both resolver backends and the daemon's one-time unlock.
+- `internal/vault/vault.go` — `VaultService` is the resident unlocked state; `Lock`, `GetCredential`, keychain unlock — needs mutex + memguard-backed key.
+- `internal/keychain/keychain.go` — daemon keychain unlock; macOS session-binding constraint.
+- `test/helpers/command.go` — the `runtime.GOOS == "darwin"` HOME-passthrough pattern the agent spawn helper must follow.

--- a/test/integration/exec_test.go
+++ b/test/integration/exec_test.go
@@ -179,6 +179,31 @@ func TestIntegration_Exec_PerMappingField(t *testing.T) {
 	}
 }
 
+// TestIntegration_Exec_PerMappingFieldSlash verifies the preferred slash
+// separator (service/field) works end-to-end through the real binary, exactly
+// like the colon form above. The colon test stays as the back-compat proof.
+func TestIntegration_Exec_PerMappingFieldSlash(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh")
+	}
+
+	configPath, password, service, secret := setupExecVault(t)
+
+	stdin := helpers.BuildUnlockStdin(password)
+	stdout, stderr, err := helpers.RunCmd(t, binaryPath, configPath, stdin,
+		"exec",
+		"--set", "DB_USER="+service+"/username",
+		"--set", "DB_PASSWORD="+service+"/password",
+		"--", "sh", "-c", `printf '%s:%s' "$DB_USER" "$DB_PASSWORD"`)
+	if err != nil {
+		t.Fatalf("exec failed: %v\nStderr: %s", err, stderr)
+	}
+	want := "execuser:" + secret
+	if strings.TrimSpace(stdout) != want {
+		t.Errorf("slash per-mapping field: stdout = %q, want %q", strings.TrimSpace(stdout), want)
+	}
+}
+
 // TestIntegration_Exec_MissingDashTerminator verifies a clear error when no "--"
 // separates the command.
 func TestIntegration_Exec_MissingDashTerminator(t *testing.T) {


### PR DESCRIPTION
## Summary

Phase 0 of the #115 (env-injection ergonomics) + #116 (agent/daemon) epic: the shared substrate every later surface builds on, plus the slash "first peg". No user-facing behavior changes — `exec` works exactly as before.

Three commits, deliberately split so the regression gate stays unambiguous:

### `docs(plan)` — design decisions
Bakes the owner's five steers into the design doc, most importantly that the slash separator is **additive** (not a breaking migration), and that only decision #1 touches Phase 0 (batched tracking / daemon snapshot / memguard are all Phase 2).

### `0a` — pure extraction, zero behavior change
- **`internal/envmap`** — the mapping grammar (`Mapping`, `DeriveEnvName`, `ParseSetSpec`), today's first-colon behavior preserved byte-for-byte.
- **`internal/resolver`** — a `Resolver` interface + read-only `directResolver`, the substrate `exec` (now) and `export`/`run`/`inject` (Phase 1) share.
- **`internal/vault.ResolveCredentialField`** — moved out of `cmd` so an internal resolver can reuse it; `get` now calls it too.
- **`cmd/exec.go`** is now a thin client: parse → `NewDirect` → `Resolve` → `runChild`.

The existing exec unit + integration suites pass **unchanged on colon `service:field`** — that's the gate proving 0a changed no behavior.

### `0b` — additive slash separator
`service/field` becomes the preferred separator; `:field` keeps working. Separator is picked by presence, **slash wins** — and in slash mode any `:` is a literal character (the actual fragility fix). Exactly two segments for now; 3+ segments error, reserving `vault/service/field` for a future multi-vault (`op://`-compatible). `envmap.SplitPath` is the single separator home, ready for Phase 1's manifest and `${pass:service/field}` templates.

## Testing

- Full unit suite green; `exec` integration green on **both** colon and slash input (colon kept as the back-compat proof, slash added alongside).
- New unit test asserts the resolver is **strictly read-only** — the vault file bytes are unchanged across a `Resolve`, the property #120's sync speed depends on.
- `golangci-lint v2.5.0` (matches CI) 0 issues; `gofmt`/`go vet` clean.

## Notes

- Nothing shipped here changes the CLI's behavior; slash is purely additive.
- Phase 1 (the #115 `export` / `inject` / `.pass-cli.toml` surfaces) builds on this substrate next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
