### PR TITLE
feat(export): 'pass-cli export' for shell env injection + value-batch resolver (#115.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`export` command — print shell statements that set credentials as env vars** (#115) — `pass-cli export` emits `export NAME='value'` for `eval`/`source`, the blessed replacement for `VAR="$(pass-cli get …)"`: `eval "$(pass-cli export --set GITHUB_TOKEN=github)"`. Uses the same mapping grammar as `exec` (repeatable `--set ENV_NAME=service[/field]` and the convenience form `pass-cli export <service>`, which derives the name from the service), and the same `-f/--field` selection. `--format sh|fish|powershell` selects the shell syntax (default `sh`). Read-only like `exec` (records no usage, triggers no sync push). Because `export` output is meant to be eval'd, env names are validated against `[A-Za-z_][A-Za-z0-9_]*` before the vault is opened, and every field value is shell-quoted per target shell.
+
+### Changed
+- **Env-injection grammar: prefer `/` over `:`** (#115) — credential references now accept a slash separator (`service/field`) in addition to the legacy colon form (`service:field`, still accepted unchanged). Slash is preferred because in slash form a `:` inside a service name is a literal character, and it lines up with a future `op://`-style path. Applies to `--set` on both `exec` and `export`.
+
 ## [0.18.0] - 2026-06-26
 
 ### Added

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -182,7 +182,7 @@ func runExec(cmd *cobra.Command, args []string) error {
 	r := resolver.NewDirect(vaultService)
 	defer func() { _ = r.Close() }()
 
-	extraEnv, err := r.Resolve(mappings, execField)
+	extraEnv, err := resolver.ResolveEnv(r, mappings, execField)
 	if err != nil {
 		return err
 	}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/arimxyer/pass-cli/internal/envmap"
+	"github.com/arimxyer/pass-cli/internal/resolver"
+	"github.com/arimxyer/pass-cli/internal/vault"
+)
+
+var (
+	exportSets   []string
+	exportField  string
+	exportFormat string
+)
+
+var exportCmd = &cobra.Command{
+	Use:     "export [<service>...]",
+	GroupID: "credentials",
+	Short:   "Print shell statements that set credentials as environment variables",
+	Long: `Export prints shell statements that assign stored credentials to environment
+variables, for evaluation by your shell:
+
+  eval "$(pass-cli export --set GITHUB_TOKEN=github)"
+
+The mapping grammar is the same as 'exec':
+
+  # Explicit mapping (repeatable): --set ENV_NAME=service[/field]
+  pass-cli export --set GITHUB_TOKEN=github --set DB_PASSWORD=postgres/password
+
+  # Convenience form: derive the env name from each service name
+  # (uppercased, non-alphanumeric characters become '_')
+  pass-cli export openai-api            # emits: export OPENAI_API='...'
+
+The -f/--field flag selects which field to export (default: password) and applies
+to every mapping; a single mapping can override it with a '/field' suffix.
+
+--format selects the shell syntax:
+  sh          export NAME='value'      (default; POSIX sh/bash/zsh, for eval)
+  fish        set -gx NAME 'value'      (for: pass-cli export ... | source)
+  powershell  $env:NAME = 'value'
+
+Security note: 'export' materializes the secret into your CURRENT shell for that
+shell's lifetime (and any process it launches can read it via the environment).
+That is a weaker boundary than 'exec', which scopes the secret to a single child
+process. Prefer 'exec' when you only need to launch a command; use 'export' as the
+blessed replacement for VAR="$(pass-cli get ...)", not as a replacement for 'exec'.`,
+	Example: `  # Load a token into the current shell
+  eval "$(pass-cli export --set GITHUB_TOKEN=github)"
+
+  # Multiple credentials, convenience form
+  eval "$(pass-cli export openai-api anthropic-api)"
+
+  # fish shell
+  pass-cli export --set GITHUB_TOKEN=github --format fish | source`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runExport,
+}
+
+func init() {
+	rootCmd.AddCommand(exportCmd)
+	exportCmd.Flags().StringArrayVar(&exportSets, "set", nil, "map an environment variable to a credential: ENV_NAME=service[/field] (repeatable; ':field' also accepted)")
+	exportCmd.Flags().StringVarP(&exportField, "field", "f", "password", "field to export for all mappings (username, password, category, url, notes, service)")
+	exportCmd.Flags().StringVar(&exportFormat, "format", "sh", "shell syntax: sh, fish, or powershell")
+}
+
+// parseExportArgs turns --set specs or positional services into mappings and
+// validates every resulting env name. Names are validated here, before the vault
+// is opened, so a bad name fails fast without fetching any secret. Unlike exec,
+// export emits shell text to be eval'd, so an invalid or attacker-controlled name
+// is a shell-injection vector — hence the ValidEnvName gate.
+func parseExportArgs(sets, positionals []string) ([]envmap.Mapping, error) {
+	var mappings []envmap.Mapping
+
+	switch {
+	case len(sets) > 0:
+		if len(positionals) > 0 {
+			return nil, fmt.Errorf("cannot combine a positional <service> (%q) with --set; use one form or the other", positionals[0])
+		}
+		for _, s := range sets {
+			m, err := envmap.ParseSetSpec(s)
+			if err != nil {
+				return nil, err
+			}
+			mappings = append(mappings, m)
+		}
+	case len(positionals) > 0:
+		for _, svc := range positionals {
+			name := envmap.DeriveEnvName(svc)
+			mappings = append(mappings, envmap.Mapping{EnvName: name, Service: svc})
+		}
+	default:
+		return nil, errors.New("specify a <service> or --set ENV_NAME=service")
+	}
+
+	for _, m := range mappings {
+		if !envmap.ValidEnvName(m.EnvName) {
+			return nil, fmt.Errorf("invalid environment variable name %q (must match [A-Za-z_][A-Za-z0-9_]*)", m.EnvName)
+		}
+	}
+	return mappings, nil
+}
+
+func runExport(cmd *cobra.Command, args []string) error {
+	format, err := exportFormatter(exportFormat)
+	if err != nil {
+		return err
+	}
+
+	mappings, err := parseExportArgs(exportSets, args)
+	if err != nil {
+		return err
+	}
+
+	vaultPath := GetVaultPath()
+	if _, err := os.Stat(vaultPath); os.IsNotExist(err) {
+		return fmt.Errorf("vault not found at %s\nRun 'pass-cli init' to create a vault first", vaultPath)
+	}
+
+	vaultService, err := vault.New(vaultPath)
+	if err != nil {
+		return fmt.Errorf("failed to create vault service at %s: %w", vaultPath, err)
+	}
+
+	// Pull from remote and unlock, overlapping the pull with the password prompt
+	// (#103; read-only: no push after).
+	if err := unlockVaultWithSync(vaultService); err != nil {
+		return err
+	}
+	defer vaultService.Lock()
+
+	// export is read-only, like exec: the resolver never records field access or
+	// triggers a sync push.
+	r := resolver.NewDirect(vaultService)
+	defer func() { _ = r.Close() }()
+
+	values, err := r.ResolveValues(mappings, exportField)
+	if err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	for i, m := range mappings {
+		if _, err := fmt.Fprintln(out, format(m.EnvName, values[i])); err != nil {
+			return fmt.Errorf("failed to write output: %w", err)
+		}
+	}
+	return nil
+}
+
+// exportFormatter returns the statement formatter for a shell format name.
+func exportFormatter(name string) (func(envName, value string) string, error) {
+	switch strings.ToLower(name) {
+	case "sh", "bash", "zsh", "":
+		return formatSh, nil
+	case "fish":
+		return formatFish, nil
+	case "powershell", "pwsh", "ps":
+		return formatPowerShell, nil
+	default:
+		return nil, fmt.Errorf("unknown --format %q (valid: sh, fish, powershell)", name)
+	}
+}
+
+// formatSh emits a POSIX single-quoted assignment. Inside single quotes every byte
+// is literal except ' itself, which is closed, escaped as \', and reopened.
+func formatSh(envName, value string) string {
+	return "export " + envName + "='" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+// formatFish emits a fish single-quoted assignment. In fish single quotes only \
+// and ' are special, escaped as \\ and \'. Backslash must be escaped first so the
+// backslashes introduced for quotes are not doubled.
+func formatFish(envName, value string) string {
+	v := strings.ReplaceAll(value, `\`, `\\`)
+	v = strings.ReplaceAll(v, "'", `\'`)
+	return "set -gx " + envName + " '" + v + "'"
+}
+
+// formatPowerShell emits a PowerShell single-quoted assignment. In a single-quoted
+// PowerShell string the only special character is ', escaped by doubling it.
+func formatPowerShell(envName, value string) string {
+	return "$env:" + envName + " = '" + strings.ReplaceAll(value, "'", "''") + "'"
+}

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -1,0 +1,192 @@
+package cmd
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/arimxyer/pass-cli/internal/envmap"
+)
+
+// adversarialValues are secret values chosen to break naive shell quoting: quotes,
+// shell metacharacters, command substitution, backslashes, a newline, and a
+// leading dash. If quoting is correct, each must round-trip byte-for-byte.
+var adversarialValues = []string{
+	"plain-token",
+	"has'single",
+	`has"double`,
+	"has$dollar",
+	"$HOME",
+	"$(id)",
+	"`id`",
+	`back\slash`,
+	"semi;colon",
+	"pipe|amp&",
+	"with space",
+	"line1\nline2",
+	"-leading-dash",
+	`all'"$()` + "`\\;",
+}
+
+// TestFormatSh_RoundTripsThroughRealShell is the load-bearing quoting test: it
+// eval's the emitted statement in a real /bin/sh and checks the variable holds the
+// exact secret. Eyeballing the quoting is not enough — this proves it.
+func TestFormatSh_RoundTripsThroughRealShell(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh")
+	}
+
+	for _, value := range adversarialValues {
+		t.Run(value, func(t *testing.T) {
+			stmt := formatSh("SECRET_VAR", value)
+			// eval the assignment, then print the variable with no added bytes.
+			script := stmt + `; printf '%s' "$SECRET_VAR"`
+			out, err := exec.Command("sh", "-c", script).Output()
+			if err != nil {
+				t.Fatalf("sh failed for %q: %v (stmt: %s)", value, err, stmt)
+			}
+			if string(out) != value {
+				t.Errorf("round-trip mismatch\n value = %q\n got   = %q\n stmt  = %s", value, string(out), stmt)
+			}
+		})
+	}
+}
+
+// TestFormatSh_NoUnintendedExecution guards specifically against command
+// substitution executing: if $(id) or `id` ran, the output would contain "uid=".
+func TestFormatSh_NoUnintendedExecution(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh")
+	}
+	for _, value := range []string{"$(id)", "`id`", "${HOME}"} {
+		stmt := formatSh("SECRET_VAR", value)
+		out, err := exec.Command("sh", "-c", stmt+`; printf '%s' "$SECRET_VAR"`).Output()
+		if err != nil {
+			t.Fatalf("sh failed: %v", err)
+		}
+		if string(out) != value {
+			t.Errorf("value %q was interpreted, got %q", value, string(out))
+		}
+		if strings.Contains(string(out), "uid=") {
+			t.Errorf("command substitution executed for %q: %q", value, string(out))
+		}
+	}
+}
+
+// TestFormatFish verifies fish single-quote escaping (\ and ' are the only
+// special characters).
+func TestFormatFish(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{"plain", `set -gx V 'plain'`},
+		{"has'quote", `set -gx V 'has\'quote'`},
+		{`back\slash`, `set -gx V 'back\\slash'`},
+		{`both\'`, `set -gx V 'both\\\''`},
+		{"$dollar", `set -gx V '$dollar'`}, // $ is literal in fish single quotes
+	}
+	for _, tt := range tests {
+		if got := formatFish("V", tt.value); got != tt.want {
+			t.Errorf("formatFish(%q) = %q, want %q", tt.value, got, tt.want)
+		}
+	}
+}
+
+// TestFormatPowerShell verifies PowerShell single-quote escaping (double the quote).
+func TestFormatPowerShell(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{"plain", `$env:V = 'plain'`},
+		{"has'quote", `$env:V = 'has''quote'`},
+		{`back\slash`, `$env:V = 'back\slash'`}, // backslash is literal in PS single quotes
+	}
+	for _, tt := range tests {
+		if got := formatPowerShell("V", tt.value); got != tt.want {
+			t.Errorf("formatPowerShell(%q) = %q, want %q", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestExportFormatter(t *testing.T) {
+	for _, name := range []string{"sh", "bash", "zsh", "", "fish", "powershell", "pwsh", "PS"} {
+		if _, err := exportFormatter(name); err != nil {
+			t.Errorf("exportFormatter(%q) unexpected error: %v", name, err)
+		}
+	}
+	if _, err := exportFormatter("cmd.exe"); err == nil {
+		t.Error("expected error for unknown format")
+	}
+}
+
+func TestParseExportArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		sets        []string
+		positionals []string
+		want        []envmap.Mapping
+		wantErr     bool
+	}{
+		{
+			name: "single --set",
+			sets: []string{"GITHUB_TOKEN=github"},
+			want: []envmap.Mapping{{EnvName: "GITHUB_TOKEN", Service: "github"}},
+		},
+		{
+			name: "slash field override",
+			sets: []string{"DB_PASSWORD=postgres/password"},
+			want: []envmap.Mapping{{EnvName: "DB_PASSWORD", Service: "postgres", Field: "password"}},
+		},
+		{
+			name:        "multiple positionals derive names",
+			positionals: []string{"openai-api", "github"},
+			want:        []envmap.Mapping{{EnvName: "OPENAI_API", Service: "openai-api"}, {EnvName: "GITHUB", Service: "github"}},
+		},
+		{
+			name:        "combine --set and positional",
+			sets:        []string{"K=svc"},
+			positionals: []string{"extra"},
+			wantErr:     true,
+		},
+		{
+			name:    "no args",
+			wantErr: true,
+		},
+		{
+			name:    "injection via --set name is rejected",
+			sets:    []string{"X;rm -rf ~=github"}, // name "X;rm -rf ~" -> would be shell injection if emitted
+			wantErr: true,
+		},
+		{
+			name:        "derived name starting with digit is rejected",
+			positionals: []string{"2fa"}, // -> "2FA", not a valid shell name
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseExportArgs(tt.sets, tt.positionals)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d mappings, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("mapping %d = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/envmap/envmap.go
+++ b/internal/envmap/envmap.go
@@ -10,8 +10,22 @@ package envmap
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
+
+// envNameRe matches a POSIX-portable environment variable name: a letter or
+// underscore followed by letters, digits, or underscores.
+var envNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// ValidEnvName reports whether name is a safe environment variable name. This
+// matters most for surfaces that emit shell text to be eval'd (export): an
+// unvalidated --set name like "X=1;rm -rf" would be literal shell injection, and
+// a derived name that starts with a digit (e.g. service "2fa" -> "2FA") is not a
+// name any shell can assign.
+func ValidEnvName(name string) bool {
+	return envNameRe.MatchString(name)
+}
 
 // Mapping pairs a target environment variable name with the credential service
 // whose field value should be injected into it. Field is the optional per-mapping

--- a/internal/envmap/envmap_test.go
+++ b/internal/envmap/envmap_test.go
@@ -71,6 +71,22 @@ func TestParseSetSpec(t *testing.T) {
 	}
 }
 
+// TestValidEnvName covers the shell-safe env-name gate export relies on.
+func TestValidEnvName(t *testing.T) {
+	valid := []string{"X", "_", "GITHUB_TOKEN", "_leading", "A1", "MY_VAR_2"}
+	invalid := []string{"", "2FA", "1", "HAS-DASH", "HAS SPACE", "HAS;SEMI", "a.b", "a/b", "X=Y"}
+	for _, n := range valid {
+		if !ValidEnvName(n) {
+			t.Errorf("ValidEnvName(%q) = false, want true", n)
+		}
+	}
+	for _, n := range invalid {
+		if ValidEnvName(n) {
+			t.Errorf("ValidEnvName(%q) = true, want false", n)
+		}
+	}
+}
+
 // TestSplitPath exercises the shared separator directly, including the
 // slash-wins / colon-literal rule that later surfaces (manifest, templates) rely on.
 func TestSplitPath(t *testing.T) {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -19,14 +19,33 @@ import (
 	"github.com/arimxyer/pass-cli/internal/vault"
 )
 
-// Resolver materializes credential mappings into "NAME=value" strings.
+// Resolver materializes credential mappings into their field values.
 type Resolver interface {
-	// Resolve turns each mapping into "NAME=value". A mapping with an empty Field
-	// falls back to defaultField. It is read-only: no usage tracking, no sync push.
-	Resolve(mappings []envmap.Mapping, defaultField string) ([]string, error)
+	// ResolveValues returns one value per mapping, in order. A mapping with an
+	// empty Field falls back to defaultField; EnvName is ignored (callers that need
+	// "NAME=value" use ResolveEnv). It is a single batch call — the socket backend
+	// resolves N mappings in one round-trip — and read-only: no usage tracking, no
+	// sync push.
+	ResolveValues(mappings []envmap.Mapping, defaultField string) ([]string, error)
 	// Close releases any backend resources. For the direct backend the caller owns
 	// the vault's lifecycle, so Close is a no-op.
 	Close() error
+}
+
+// ResolveEnv is a convenience over ResolveValues that returns "NAME=value" entries,
+// one per mapping. Building the entry here (rather than in the backend) keeps the
+// resolver primitive value-only, so template rendering can reuse ResolveValues
+// without parsing a "NAME=" prefix back off.
+func ResolveEnv(r Resolver, mappings []envmap.Mapping, defaultField string) ([]string, error) {
+	values, err := r.ResolveValues(mappings, defaultField)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, len(mappings))
+	for i, m := range mappings {
+		out[i] = m.EnvName + "=" + values[i]
+	}
+	return out, nil
 }
 
 // directResolver resolves against an already-unlocked, in-process VaultService.
@@ -41,19 +60,19 @@ func NewDirect(vs *vault.VaultService) Resolver {
 	return &directResolver{vs: vs}
 }
 
-func (d *directResolver) Resolve(mappings []envmap.Mapping, defaultField string) ([]string, error) {
+func (d *directResolver) ResolveValues(mappings []envmap.Mapping, defaultField string) ([]string, error) {
 	out := make([]string, 0, len(mappings))
 	for _, m := range mappings {
-		// A per-mapping field (service:field) overrides the caller's default field.
+		// A per-mapping field (service/field) overrides the caller's default field.
 		field := m.Field
 		if field == "" {
 			field = defaultField
 		}
-		entry, err := buildEnvEntry(d.vs, m, field)
+		value, err := resolveOne(d.vs, m.Service, field)
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, entry)
+		out = append(out, value)
 	}
 	return out, nil
 }
@@ -61,15 +80,15 @@ func (d *directResolver) Resolve(mappings []envmap.Mapping, defaultField string)
 // Close is a no-op: the direct backend does not own the vault.
 func (d *directResolver) Close() error { return nil }
 
-// buildEnvEntry fetches one credential, resolves the requested field, and returns
-// the "NAME=value" string. The credential's secret bytes are cleared before the
-// function returns; the field value is read first, so the wiped bytes never affect
-// the returned string.
-func buildEnvEntry(vs *vault.VaultService, m envmap.Mapping, field string) (string, error) {
+// resolveOne fetches one credential and returns the requested field's value. The
+// credential's secret bytes are cleared before the function returns; the field
+// value is read (copied into a new string) first, so the wiped bytes never affect
+// the returned value.
+func resolveOne(vs *vault.VaultService, service, field string) (string, error) {
 	// GetCredential returns a deep copy, so clearing Password does not touch the vault.
-	cred, err := vs.GetCredential(m.Service, false)
+	cred, err := vs.GetCredential(service, false)
 	if err != nil {
-		return "", fmt.Errorf("failed to get credential %q: %w", m.Service, err)
+		return "", fmt.Errorf("failed to get credential %q: %w", service, err)
 	}
 	defer crypto.ClearBytes(cred.Password)
 
@@ -77,5 +96,5 @@ func buildEnvEntry(vs *vault.VaultService, m envmap.Mapping, field string) (stri
 	if err != nil {
 		return "", err
 	}
-	return m.EnvName + "=" + value, nil
+	return value, nil
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -45,12 +45,12 @@ func TestDirectResolver_ResolvesFields(t *testing.T) {
 	r := NewDirect(vs)
 	defer func() { _ = r.Close() }()
 
-	got, err := r.Resolve([]envmap.Mapping{
+	got, err := ResolveEnv(r, []envmap.Mapping{
 		{EnvName: "GITHUB_TOKEN", Service: "github"},               // default field
 		{EnvName: "GH_USER", Service: "github", Field: "username"}, // per-mapping override
 	}, "password")
 	if err != nil {
-		t.Fatalf("Resolve: %v", err)
+		t.Fatalf("ResolveEnv: %v", err)
 	}
 
 	want := []string{"GITHUB_TOKEN=s3cr3t-pw", "GH_USER=octocat"}
@@ -73,12 +73,34 @@ func TestDirectResolver_DefaultFieldFallback(t *testing.T) {
 	r := NewDirect(vs)
 	defer func() { _ = r.Close() }()
 
-	got, err := r.Resolve([]envmap.Mapping{{EnvName: "GH", Service: "github"}}, "username")
+	got, err := ResolveEnv(r, []envmap.Mapping{{EnvName: "GH", Service: "github"}}, "username")
 	if err != nil {
-		t.Fatalf("Resolve: %v", err)
+		t.Fatalf("ResolveEnv: %v", err)
 	}
 	if len(got) != 1 || got[0] != "GH=octocat" {
 		t.Errorf("got %v, want [GH=octocat]", got)
+	}
+}
+
+// TestDirectResolver_ResolveValuesOrder verifies ResolveValues returns bare values
+// in mapping order (the primitive the template renderer builds on).
+func TestDirectResolver_ResolveValuesOrder(t *testing.T) {
+	vs, _ := newUnlockedVault(t)
+	defer vs.Lock()
+
+	r := NewDirect(vs)
+	defer func() { _ = r.Close() }()
+
+	got, err := r.ResolveValues([]envmap.Mapping{
+		{Service: "github", Field: "username"},
+		{Service: "github"}, // default field
+	}, "password")
+	if err != nil {
+		t.Fatalf("ResolveValues: %v", err)
+	}
+	want := []string{"octocat", "s3cr3t-pw"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("ResolveValues = %v, want %v", got, want)
 	}
 }
 
@@ -96,7 +118,7 @@ func TestDirectResolver_ReadOnly_DoesNotMutateVault(t *testing.T) {
 
 	r := NewDirect(vs)
 	defer func() { _ = r.Close() }()
-	if _, err := r.Resolve([]envmap.Mapping{{EnvName: "GH", Service: "github"}}, "password"); err != nil {
+	if _, err := r.ResolveValues([]envmap.Mapping{{EnvName: "GH", Service: "github"}}, "password"); err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
 
@@ -117,7 +139,7 @@ func TestDirectResolver_UnknownService(t *testing.T) {
 	r := NewDirect(vs)
 	defer func() { _ = r.Close() }()
 
-	if _, err := r.Resolve([]envmap.Mapping{{EnvName: "X", Service: "nonexistent"}}, "password"); err == nil {
+	if _, err := r.ResolveValues([]envmap.Mapping{{EnvName: "X", Service: "nonexistent"}}, "password"); err == nil {
 		t.Fatal("expected error for unknown service, got nil")
 	}
 }
@@ -130,7 +152,7 @@ func TestDirectResolver_InvalidField(t *testing.T) {
 	r := NewDirect(vs)
 	defer func() { _ = r.Close() }()
 
-	if _, err := r.Resolve([]envmap.Mapping{{EnvName: "X", Service: "github", Field: "totp"}}, "password"); err == nil {
+	if _, err := r.ResolveValues([]envmap.Mapping{{EnvName: "X", Service: "github", Field: "totp"}}, "password"); err == nil {
 		t.Fatal("expected error for invalid field, got nil")
 	}
 }

--- a/test/integration/export_test.go
+++ b/test/integration/export_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/arimxyer/pass-cli/test/helpers"
+)
+
+// evalSh eval's a shell statement in a real /bin/sh and returns the named
+// variable's value with no added bytes.
+func evalSh(t *testing.T, stmt, varName string) string {
+	t.Helper()
+	out, err := exec.Command("sh", "-c", stmt+`; printf '%s' "$`+varName+`"`).Output()
+	if err != nil {
+		t.Fatalf("sh eval failed for %q: %v", stmt, err)
+	}
+	return string(out)
+}
+
+// TestIntegration_Export_RoundTrip proves the full path: the binary emits an
+// export statement, and eval'ing it in a real shell yields the exact secret.
+func TestIntegration_Export_RoundTrip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh")
+	}
+	configPath, password, service, secret := setupExecVault(t)
+
+	stdin := helpers.BuildUnlockStdin(password)
+	stdout, stderr, err := helpers.RunCmd(t, binaryPath, configPath, stdin,
+		"export", "--set", "MY_TOKEN="+service)
+	if err != nil {
+		t.Fatalf("export failed: %v\nStderr: %s", err, stderr)
+	}
+	stmt := strings.TrimSpace(stdout)
+	if got := evalSh(t, stmt, "MY_TOKEN"); got != secret {
+		t.Errorf("eval round-trip: got %q, want %q\nstmt: %s", got, secret, stmt)
+	}
+}
+
+// TestIntegration_Export_AdversarialSecret round-trips a secret whose value
+// contains quotes and command substitution — the end-to-end quoting proof.
+func TestIntegration_Export_AdversarialSecret(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX sh")
+	}
+	configPath, password, _, _ := setupExecVault(t)
+	tricky := `a'b"c$(id)` + "`id`" + `\x;|&`
+
+	if _, stderr, err := helpers.RunCmd(t, binaryPath, configPath, helpers.BuildUnlockStdin(password),
+		"add", "trickysvc", "--username", "u", "--password", tricky); err != nil {
+		t.Fatalf("add failed: %v\nStderr: %s", err, stderr)
+	}
+
+	stdout, stderr, err := helpers.RunCmd(t, binaryPath, configPath, helpers.BuildUnlockStdin(password),
+		"export", "--set", "TRICKY=trickysvc")
+	if err != nil {
+		t.Fatalf("export failed: %v\nStderr: %s", err, stderr)
+	}
+	stmt := strings.TrimSpace(stdout)
+	got := evalSh(t, stmt, "TRICKY")
+	if got != tricky {
+		t.Errorf("adversarial round-trip: got %q, want %q\nstmt: %s", got, tricky, stmt)
+	}
+	if strings.Contains(got, "uid=") {
+		t.Errorf("command substitution executed: %q", got)
+	}
+}
+
+// TestIntegration_Export_FishFormat verifies the fish syntax is emitted.
+func TestIntegration_Export_FishFormat(t *testing.T) {
+	configPath, password, service, secret := setupExecVault(t)
+
+	stdout, stderr, err := helpers.RunCmd(t, binaryPath, configPath, helpers.BuildUnlockStdin(password),
+		"export", "--set", "TOK="+service, "--format", "fish")
+	if err != nil {
+		t.Fatalf("export failed: %v\nStderr: %s", err, stderr)
+	}
+	want := "set -gx TOK '" + secret + "'" // secret has no fish-special chars
+	if strings.TrimSpace(stdout) != want {
+		t.Errorf("fish format: got %q, want %q", strings.TrimSpace(stdout), want)
+	}
+}
+
+// TestIntegration_Export_RejectsInvalidName verifies a shell-injecting env name is
+// rejected before the vault is even opened.
+func TestIntegration_Export_RejectsInvalidName(t *testing.T) {
+	configPath, password, service, _ := setupExecVault(t)
+
+	stdout, stderr, err := helpers.RunCmd(t, binaryPath, configPath, helpers.BuildUnlockStdin(password),
+		"export", "--set", "BAD;NAME="+service)
+	if err == nil {
+		t.Fatalf("expected error for invalid env name, got success\nStdout: %s", stdout)
+	}
+	if !strings.Contains(stderr, "invalid environment variable name") {
+		t.Errorf("expected invalid-name error, got stderr: %s", stderr)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1.1 of the #115 env-injection epic: **`pass-cli export`**, the blessed replacement for `VAR="$(pass-cli get …)"`. Builds directly on the Phase 0 resolver substrate (#121).

```sh
eval "$(pass-cli export --set GITHUB_TOKEN=github)"
eval "$(pass-cli export openai-api anthropic-api)"      # convenience form
pass-cli export --set TOK=github --format fish | source
```

Two commits:

### `refactor(resolver)` — value-returning + batch primitive
`Resolve` → `ResolveValues([]Mapping, defaultField) ([]string, error)`: returns bare values in mapping order in **one batch call** (Phase 2's socket resolves N refs in a single round-trip). `ResolveEnv` is now a free helper that builds `NAME=value` on top, so the upcoming template renderer can reuse `ResolveValues` without parsing a `NAME=` prefix back off. `exec` re-routes through `ResolveEnv`; its gate is unchanged. Still strictly read-only.

### `feat(export)` — the command
- Same grammar as `exec` (`--set NAME=service/field`, positional convenience, `-f/--field`); `--format sh|fish|powershell`.
- Read-only via the shared resolver — no usage write, no sync push.

## Security

`export` emits shell text that gets `eval`'d, so it has two injection surfaces `exec` doesn't (exec sets env structurally in Go):

1. **Env-name validation** — names are checked against `[A-Za-z_][A-Za-z0-9_]*` **before the vault is opened**. An unvalidated `--set` name (`X;rm -rf=svc`) would be literal shell injection; a derived name starting with a digit (`2fa` → `2FA`) is not a name any shell can assign. Both are rejected, fast, without fetching a secret.
2. **Per-shell quoting** — single-quote escaping per target (`sh` `'\''`, `fish` `\` then `'`, `pwsh` `''`), verified by **round-tripping 14 adversarial values** (quotes, `$()`, backticks, backslash, newline, leading dash) through a real `/bin/sh`, plus an end-to-end integration test that eval's the binary's actual output and byte-compares against a quote-laden stored secret (and asserts command substitution never fires).

## Testing

- Unit: format round-trip through real `sh`, no-unintended-execution guard, fish/pwsh escaping, `ValidEnvName`, arg parsing (incl. both injection rejections), and a `ResolveValues` order test.
- Integration: end-to-end eval round-trip (plain + adversarial secret), fish format, invalid-name rejection.
- Full unit + integration suites green; `golangci-lint v2.5.0` 0 issues; `gofmt`/`vet` clean.
- CHANGELOG updated (export + the additive slash grammar, both Unreleased).

## Docs note

The design doc reframes `run --env-file` as folding into `exec --env-file` (avoids a near-duplicate command). That's the **next** PR (template engine + `inject`) and I'll confirm the surface with you before building it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
