### PR TITLE
feat(agent): in-process agent core + protocol (#116 Phase 2a)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,0 +1,203 @@
+package agent
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/arimxyer/pass-cli/internal/envmap"
+	"github.com/arimxyer/pass-cli/internal/resolver"
+	"github.com/arimxyer/pass-cli/internal/vault"
+)
+
+// Clock abstracts time so auto-lock timers are testable without real sleeps.
+type Clock interface{ Now() time.Time }
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time { return time.Now() }
+
+// Logger records agent events. Its signature accepts an event name and optional
+// service names ONLY — there is no parameter through which a field value could be
+// passed — so it is structurally incapable of logging a secret. (The protocol
+// carries secrets; the log must not.)
+type Logger interface {
+	Event(event string, services []string)
+}
+
+type nopLogger struct{}
+
+func (nopLogger) Event(string, []string) {}
+
+// WriterLogger writes one line per event to W, emitting only the event name and
+// service names.
+type WriterLogger struct{ W io.Writer }
+
+func (l WriterLogger) Event(event string, services []string) {
+	// Best-effort logging; a failed write to stderr must not affect resolve.
+	if len(services) > 0 {
+		_, _ = fmt.Fprintf(l.W, "[agent] %s services=%v\n", event, services)
+	} else {
+		_, _ = fmt.Fprintf(l.W, "[agent] %s\n", event)
+	}
+}
+
+// Options configures an Agent. Zero values mean: no idle lock, no max-TTL,
+// system clock, no-op logger.
+type Options struct {
+	IdleTimeout time.Duration
+	MaxTTL      time.Duration
+	Clock       Clock
+	Logger      Logger
+}
+
+// Agent is the mutex-guarded, resident unlocked vault. It answers read-only
+// resolve requests and auto-locks on idle/max-TTL. It does not own any transport;
+// a server feeds it decoded Requests via Handle.
+type Agent struct {
+	mu           sync.Mutex
+	vs           *vault.VaultService
+	clock        Clock
+	idleTimeout  time.Duration
+	maxTTL       time.Duration
+	log          Logger
+	unlockedAt   time.Time
+	lastActivity time.Time
+	locked       bool
+}
+
+// New wraps an already-unlocked VaultService. The caller unlocks the vault (via a
+// password prompt or keychain) before constructing the Agent; the Agent then owns
+// its lifecycle (Lock on idle/max-TTL/shutdown).
+func New(vs *vault.VaultService, opts Options) *Agent {
+	clock := opts.Clock
+	if clock == nil {
+		clock = systemClock{}
+	}
+	log := opts.Logger
+	if log == nil {
+		log = nopLogger{}
+	}
+	now := clock.Now()
+	return &Agent{
+		vs:           vs,
+		clock:        clock,
+		idleTimeout:  opts.IdleTimeout,
+		maxTTL:       opts.MaxTTL,
+		log:          log,
+		unlockedAt:   now,
+		lastActivity: now,
+	}
+}
+
+// Handle processes one decoded request under the agent mutex and returns the
+// response. Every call first enforces auto-lock, so a request that arrives after
+// the idle/max-TTL window finds the agent already locked.
+func (a *Agent) Handle(req Request) Response {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Version 0 is treated as "unspecified" and accepted for forward compatibility
+	// in tests; any explicit mismatch is refused so the client falls back.
+	if req.Version != 0 && req.Version != ProtocolVersion {
+		return errResponse(fmt.Sprintf("unsupported protocol version %d (agent speaks %d)", req.Version, ProtocolVersion))
+	}
+
+	a.enforceAutoLock()
+
+	switch req.Method {
+	case MethodStatus:
+		return a.handleStatus()
+	case MethodLock:
+		a.lockLocked("lock")
+		return okResponse()
+	case MethodShutdown:
+		a.lockLocked("shutdown")
+		return okResponse()
+	case MethodResolve:
+		return a.handleResolve(req.Resolve)
+	default:
+		return errResponse(fmt.Sprintf("unknown method %q", req.Method))
+	}
+}
+
+// Locked reports whether the resident vault has been locked (test/introspection).
+func (a *Agent) Locked() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.enforceAutoLock()
+	return a.locked
+}
+
+func (a *Agent) handleResolve(p *ResolveParams) Response {
+	if a.locked {
+		return errResponse("agent is locked; re-unlock with 'pass-cli agent'")
+	}
+	if p == nil {
+		return errResponse("resolve: missing parameters")
+	}
+
+	mappings := make([]envmap.Mapping, len(p.Refs))
+	services := make([]string, len(p.Refs))
+	for i, ref := range p.Refs {
+		mappings[i] = envmap.Mapping{Service: ref.Service, Field: ref.Field}
+		services[i] = ref.Service
+	}
+
+	// The resident vault is served through the same strictly read-only resolver the
+	// one-shot CLI uses: no usage write, no sync push.
+	values, err := resolver.NewDirect(a.vs).ResolveValues(mappings, p.DefaultField)
+	if err != nil {
+		// The error may name a service, but never a field value.
+		a.log.Event("resolve_error", services)
+		return errResponse(err.Error())
+	}
+
+	a.lastActivity = a.clock.Now()
+	a.log.Event("resolve", services) // service names only — never values
+	return Response{Version: ProtocolVersion, OK: true, Values: values}
+}
+
+func (a *Agent) handleStatus() Response {
+	now := a.clock.Now()
+	st := &Status{Unlocked: !a.locked}
+	if !a.locked {
+		st.IdleSeconds = int64(now.Sub(a.lastActivity).Seconds())
+		if a.maxTTL > 0 {
+			rem := a.maxTTL - now.Sub(a.unlockedAt)
+			if rem < 0 {
+				rem = 0
+			}
+			st.MaxTTLRemainingSeconds = int64(rem.Seconds())
+		}
+	}
+	return Response{Version: ProtocolVersion, OK: true, Status: st}
+}
+
+// enforceAutoLock locks the resident vault if the idle timeout or max-TTL has
+// elapsed. Must be called with a.mu held.
+func (a *Agent) enforceAutoLock() {
+	if a.locked {
+		return
+	}
+	now := a.clock.Now()
+	if a.idleTimeout > 0 && now.Sub(a.lastActivity) >= a.idleTimeout {
+		a.lockLocked("idle_lock")
+		return
+	}
+	if a.maxTTL > 0 && now.Sub(a.unlockedAt) >= a.maxTTL {
+		a.lockLocked("max_ttl_lock")
+	}
+}
+
+// lockLocked zeros the resident secrets and marks the agent locked. Idempotent.
+// Must be called with a.mu held.
+func (a *Agent) lockLocked(reason string) {
+	if a.locked {
+		return
+	}
+	a.vs.Lock() // zero secrets via crypto.ClearBytes
+	a.locked = true
+	a.log.Event(reason, nil)
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,181 @@
+package agent
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arimxyer/pass-cli/internal/vault"
+)
+
+const testSecret = "s3cr3t-pw-agent"
+
+// fakeClock is a manually-advanced clock for deterministic auto-lock tests.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+func newTestVault(t *testing.T) *vault.VaultService {
+	t.Helper()
+	dir := t.TempDir()
+	vs, err := vault.New(filepath.Join(dir, "vault.enc"))
+	if err != nil {
+		t.Fatalf("vault.New: %v", err)
+	}
+	if err := vs.Initialize([]byte("TestPassword123!"), false, filepath.Join(dir, "audit.log"), "agent-test"); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := vs.Unlock([]byte("TestPassword123!")); err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	if err := vs.AddCredential("github", "octocat", []byte(testSecret), "vcs", "https://github.com", ""); err != nil {
+		t.Fatalf("AddCredential: %v", err)
+	}
+	return vs
+}
+
+func resolveReq(refs ...Ref) Request {
+	return Request{Version: ProtocolVersion, Method: MethodResolve, Resolve: &ResolveParams{Refs: refs, DefaultField: "password"}}
+}
+
+func TestAgent_Resolve(t *testing.T) {
+	a := New(newTestVault(t), Options{})
+	resp := a.Handle(resolveReq(Ref{Service: "github"}, Ref{Service: "github", Field: "username"}))
+	if !resp.OK {
+		t.Fatalf("resolve failed: %s", resp.Error)
+	}
+	want := []string{testSecret, "octocat"}
+	if len(resp.Values) != len(want) || resp.Values[0] != want[0] || resp.Values[1] != want[1] {
+		t.Errorf("values = %v, want %v", resp.Values, want)
+	}
+}
+
+func TestAgent_UnknownMethodAndNoKeyExport(t *testing.T) {
+	a := New(newTestVault(t), Options{})
+	// There is no key-export method by construction; any such request is unknown.
+	for _, m := range []string{"get-key", "get-password", "getMasterPassword", "export-key", "bogus"} {
+		resp := a.Handle(Request{Version: ProtocolVersion, Method: m})
+		if resp.OK {
+			t.Errorf("method %q unexpectedly handled", m)
+		}
+	}
+}
+
+func TestAgent_VersionMismatch(t *testing.T) {
+	a := New(newTestVault(t), Options{})
+	resp := a.Handle(Request{Version: ProtocolVersion + 1, Method: MethodStatus})
+	if resp.OK {
+		t.Error("expected version mismatch to be refused")
+	}
+}
+
+func TestAgent_LockRefusesResolve(t *testing.T) {
+	a := New(newTestVault(t), Options{})
+	if resp := a.Handle(Request{Version: ProtocolVersion, Method: MethodLock}); !resp.OK {
+		t.Fatalf("lock failed: %s", resp.Error)
+	}
+	resp := a.Handle(resolveReq(Ref{Service: "github"}))
+	if resp.OK {
+		t.Error("resolve after lock should fail")
+	}
+	if !a.Locked() {
+		t.Error("agent should report locked")
+	}
+}
+
+func TestAgent_IdleTimeoutLocks(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	a := New(newTestVault(t), Options{IdleTimeout: 15 * time.Minute, Clock: clk})
+
+	// Just under the timeout: still resolves.
+	clk.advance(14 * time.Minute)
+	if resp := a.Handle(resolveReq(Ref{Service: "github"})); !resp.OK {
+		t.Fatalf("resolve within idle window failed: %s", resp.Error)
+	}
+
+	// Idle past the timeout from the last activity: locks.
+	clk.advance(16 * time.Minute)
+	if resp := a.Handle(resolveReq(Ref{Service: "github"})); resp.OK {
+		t.Error("resolve after idle timeout should fail")
+	}
+	if !a.Locked() {
+		t.Error("agent should be locked after idle timeout")
+	}
+}
+
+func TestAgent_MaxTTLLocks(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	a := New(newTestVault(t), Options{MaxTTL: 8 * time.Hour, IdleTimeout: 24 * time.Hour, Clock: clk})
+
+	// Active use keeps resetting idle, but max-TTL is a hard cap.
+	for i := 0; i < 7; i++ {
+		clk.advance(1 * time.Hour)
+		if resp := a.Handle(resolveReq(Ref{Service: "github"})); !resp.OK {
+			t.Fatalf("resolve at hour %d failed: %s", i, resp.Error)
+		}
+	}
+	clk.advance(2 * time.Hour) // now past 8h since unlock
+	if resp := a.Handle(resolveReq(Ref{Service: "github"})); resp.OK {
+		t.Error("resolve after max-TTL should fail despite activity")
+	}
+}
+
+func TestAgent_Status(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	a := New(newTestVault(t), Options{MaxTTL: time.Hour, Clock: clk})
+
+	clk.advance(10 * time.Minute)
+	resp := a.Handle(Request{Version: ProtocolVersion, Method: MethodStatus})
+	if !resp.OK || resp.Status == nil {
+		t.Fatalf("status failed: %+v", resp)
+	}
+	if !resp.Status.Unlocked {
+		t.Error("expected unlocked")
+	}
+	if resp.Status.IdleSeconds != int64((10 * time.Minute).Seconds()) {
+		t.Errorf("idle = %d, want %d", resp.Status.IdleSeconds, int64((10 * time.Minute).Seconds()))
+	}
+	if resp.Status.MaxTTLRemainingSeconds != int64((50 * time.Minute).Seconds()) {
+		t.Errorf("ttl remaining = %d, want %d", resp.Status.MaxTTLRemainingSeconds, int64((50 * time.Minute).Seconds()))
+	}
+}
+
+// TestAgent_LoggerNeverEmitsSecret resolves with a real WriterLogger and asserts
+// the secret value never appears in the log output. The Logger interface cannot
+// even receive a value, but this pins that no future path leaks one.
+func TestAgent_LoggerNeverEmitsSecret(t *testing.T) {
+	var buf bytes.Buffer
+	a := New(newTestVault(t), Options{Logger: WriterLogger{W: &buf}})
+
+	resp := a.Handle(resolveReq(Ref{Service: "github"}))
+	if !resp.OK {
+		t.Fatalf("resolve failed: %s", resp.Error)
+	}
+	// Trigger lock/status events too, to exercise more log paths.
+	a.Handle(Request{Version: ProtocolVersion, Method: MethodStatus})
+	a.Handle(Request{Version: ProtocolVersion, Method: MethodLock})
+
+	logged := buf.String()
+	if strings.Contains(logged, testSecret) {
+		t.Errorf("secret leaked into agent log:\n%s", logged)
+	}
+	if !strings.Contains(logged, "resolve") || !strings.Contains(logged, "github") {
+		t.Errorf("expected non-secret event context in log, got:\n%s", logged)
+	}
+}
+
+// TestAgent_ResolveErrorNoValueLeak verifies a resolve error message names the
+// service but not any value (unknown service here).
+func TestAgent_ResolveErrorNoValueLeak(t *testing.T) {
+	a := New(newTestVault(t), Options{})
+	resp := a.Handle(resolveReq(Ref{Service: "nonexistent"}))
+	if resp.OK {
+		t.Fatal("expected error for unknown service")
+	}
+	if strings.Contains(resp.Error, testSecret) {
+		t.Errorf("error leaked a secret: %s", resp.Error)
+	}
+}

--- a/internal/agent/protocol.go
+++ b/internal/agent/protocol.go
@@ -1,0 +1,74 @@
+// Package agent implements the in-process core of the background credential agent
+// (#116): a mutex-guarded, resident unlocked vault that answers read-only resolve
+// requests, with idle/max-TTL auto-locking. This package is transport-agnostic —
+// it takes a decoded Request and returns a Response — so all of its logic is unit-
+// testable without binding a socket. The socket/named-pipe transport, peer-cred
+// auth, and memguard key handling live in later, separately-reviewed changes.
+//
+// Core security invariant: the agent serves resolved field VALUES only. There is
+// no protocol method that returns the master password or the derived key — by
+// construction, not by a runtime check (see the Method constants below). A
+// compromised client gets the secrets it was already going to inject, nothing more.
+package agent
+
+// ProtocolVersion is the wire-protocol version. A client whose version does not
+// match is refused (it should fall back to direct-open).
+const ProtocolVersion = 1
+
+// Method names. Note there is deliberately NO "get-key" / "get-password" method:
+// the key never crosses the wire. Adding one would break the core invariant.
+const (
+	MethodResolve  = "resolve"  // resolve field values for a batch of mappings
+	MethodLock     = "lock"     // zero the resident secrets, keep the process alive
+	MethodStatus   = "status"   // report unlocked/idle/ttl (never secrets)
+	MethodShutdown = "shutdown" // lock and signal the server to stop
+)
+
+// Ref is one credential reference in a resolve request: a service and an optional
+// field ("" means the request's DefaultField). It carries no env name — the client
+// builds "NAME=value" itself after receiving the value — and no value ever travels
+// in this direction.
+type Ref struct {
+	Service string `json:"service"`
+	Field   string `json:"field,omitempty"`
+}
+
+// ResolveParams are the parameters of a resolve request.
+type ResolveParams struct {
+	Refs         []Ref  `json:"refs"`
+	DefaultField string `json:"default_field,omitempty"`
+}
+
+// Request is a single agent request. Method selects the operation; Resolve is set
+// only for MethodResolve.
+type Request struct {
+	Version int            `json:"version"`
+	Method  string         `json:"method"`
+	Resolve *ResolveParams `json:"resolve,omitempty"`
+}
+
+// Status is the non-secret status snapshot returned by MethodStatus.
+type Status struct {
+	Unlocked               bool  `json:"unlocked"`
+	IdleSeconds            int64 `json:"idle_seconds"`
+	MaxTTLRemainingSeconds int64 `json:"max_ttl_remaining_seconds"`
+}
+
+// Response is the reply to a Request. On success OK is true; for a resolve, Values
+// holds one value per requested Ref, in order. On failure OK is false and Error
+// carries a message (which may name a service, but never a field value).
+type Response struct {
+	Version int      `json:"version"`
+	OK      bool     `json:"ok"`
+	Error   string   `json:"error,omitempty"`
+	Values  []string `json:"values,omitempty"`
+	Status  *Status  `json:"status,omitempty"`
+}
+
+func okResponse() Response {
+	return Response{Version: ProtocolVersion, OK: true}
+}
+
+func errResponse(msg string) Response {
+	return Response{Version: ProtocolVersion, OK: false, Error: msg}
+}

--- a/plans/2026-06-30-daemon-and-env-injection-plan.md
+++ b/plans/2026-06-30-daemon-and-env-injection-plan.md
@@ -128,6 +128,16 @@ Why slash and not `${pass:service:field}`: the template is exactly where the col
 
 ## 5. Phase 2 — the agent (#116) and the socket backend
 
+**Sub-PR decomposition (2026-07-01).** Phase 2 ships as sequenced sub-PRs so the two security-critical changes get isolated, focused review. Owner gate: auto-merge-on-green the *plumbing* PRs (2a/2b/2e); **hold the security PRs (2c/2d/2f) for explicit review**:
+- **2a — protocol + in-process agent core (no I/O).** `internal/agent`: `Request`/`Response` (no key-export method by construction), the mutex-guarded resident `Agent` with read-only resolve (reusing `resolver.NewDirect`), idle/max-TTL auto-lock on an injected `Clock`, and a `Logger` structurally incapable of emitting a value. Fully unit-tested incl. rejection/leak paths. **← this PR.**
+- **2b — unix-socket transport + `agent`/`stop`/`status`/`lock` commands + `socketResolver` + client try-socket-then-fallback.** Socket dir `0700` / socket `0600` land **here** (filesystem perms are the primary access control per §5.3 — not deferred to 2c). Plumbing.
+- **2c — peer-cred auth (Linux `SO_PEERCRED`).** Security-critical; decision (`uid==owner`) separated from the syscall so it's table-testable and fail-closed. **Hold for review.**
+- **2d — memguard for the resident key.** Confined to `internal/agent` (the daemon derives/guards its *own* Enclave; `VaultService.masterPassword` is untouched). Security-critical. **Hold for review.**
+- **2e — revalidating cache + batched usage tracking.** Local-file staleness refresh (§5.8), coalesced `track` write-back that re-reads current on-disk vault. Plumbing.
+- **2f — cross-platform (macOS `getpeereid`, Windows named pipe + ACL peer-cred).** Runs only in CI on those runners. Security-critical. **Hold for review.**
+
+The subsections below are the full design; each sub-PR implements its slice.
+
 ### 5.1 Process & commands
 New `cmd/agent.go` group:
 - `pass-cli agent` — start (foreground by default; `--daemonize` to background). Unlocks once via `unlockVaultWithSync`, then serves.


### PR DESCRIPTION
## Summary

Phase 2a of the #116 background agent: the **transport-agnostic in-process core**. It takes a decoded `Request` and returns a `Response`, so all of its logic is unit-testable with no socket. Socket transport (2b), peer-cred (2c), and memguard (2d) follow separately — see the [decomposition](../blob/main/plans/2026-06-30-daemon-and-env-injection-plan.md) in the design doc §5.

> **Plumbing PR** — pure logic, no I/O, fully tested locally, so it's in the auto-merge-on-green tier. The security-critical PRs (2c peer-cred, 2d memguard, 2f cross-platform) are held for your review per our agreed gate.

## What's here

- **`protocol.go`** — `Request`/`Response` and the `resolve`/`lock`/`status`/`shutdown` methods. **There is no key-export method by construction**: the master password / derived key never crosses the wire (the ssh-agent invariant). A resolve carries `{service, field}` refs and gets back values in order — the client builds `NAME=value` itself.
- **`agent.go`** — the mutex-guarded resident `Agent` over an already-unlocked `VaultService`:
  - resolve routes through `resolver.NewDirect` — the *same strictly read-only path* the one-shot CLI uses (no usage write, no sync push);
  - idle + max-TTL **auto-lock on an injected `Clock`** (deterministic, no real sleeps);
  - a `Logger` that accepts only an event name + service names — **structurally incapable of receiving a value**.

## The tests that matter at this boundary

Green CI under-verifies a daemon unless the *rejection/leak* paths are tested, so those are the focus:
- no key-export method is handled (`get-key`/`get-password`/… all refused);
- resolve is **refused once locked**;
- idle-timeout and max-TTL lock deterministically via a fake clock (max-TTL caps even under continuous activity);
- a resolve error names the service but **leaks no value**;
- the `WriterLogger` output **never contains a known secret** after resolve/status/lock.

All 9 tests pass; `golangci-lint v2.5.0` 0 issues; `gofmt`/`vet` clean.

## Not here (by design)

Socket/named-pipe transport, the `agent`/`stop`/`status`/`lock` commands, `socketResolver` + client fallback (2b); peer-cred (2c); memguard (2d); revalidating cache + batched tracking (2e); cross-platform (2f).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
