### PR TITLE
docs(agent): service unit templates + operations guide (#116 Phase 3)

### DIFF
--- a/docs/05-operations/_index.md
+++ b/docs/05-operations/_index.md
@@ -8,4 +8,5 @@ Operational guides for maintaining, monitoring, and securing pass-cli in product
 {{< cards >}}
   {{< card link="health-checks" title="Health Checks" icon="heart" subtitle="System diagnostics and vault health monitoring" >}}
   {{< card link="security-operations" title="Security Operations" icon="shield-exclamation" subtitle="Best practices, checklists, and incident response" >}}
+  {{< card link="agent" title="Background Agent" icon="lightning-bolt" subtitle="Promptless, cached credential access via a local socket" >}}
 {{< /cards >}}

--- a/docs/05-operations/agent.md
+++ b/docs/05-operations/agent.md
@@ -1,0 +1,75 @@
+# Background Agent
+
+`pass-cli agent` unlocks the vault once and holds it in memory, answering read-only
+credential lookups over a local socket. With an agent running, `exec`, `export`,
+and `inject` need **no master-password prompt and no key derivation** on each call.
+When no agent is running, every command transparently falls back to opening and
+unlocking the vault directly — the agent is a pure optimization, never a
+dependency.
+
+## Running on demand
+
+```sh
+pass-cli agent &                                  # unlock once, serve in background
+pass-cli exec --set GITHUB_TOKEN=github -- gh repo list   # resolves via the agent
+pass-cli agent status                             # unlocked? idle? max-ttl left?
+pass-cli lock                                     # lock without stopping the process
+pass-cli agent stop                               # lock and exit
+```
+
+Flags:
+
+- `--idle 15m` — lock the vault after this much inactivity (`0` = never).
+- `--max-ttl 8h` — hard cap on how long the vault stays unlocked, regardless of use.
+
+The agent locks and exits on `SIGINT`/`SIGTERM`, and re-locks (freeing the socket)
+when idle/max-TTL elapses.
+
+## Security model
+
+- The agent serves resolved field **values only**. The master password and derived
+  key never cross the socket — there is no protocol method that returns them.
+- **Socket access control:** the socket directory is `0700` and the socket `0600`.
+  On Linux, connections are additionally authorized by peer credential
+  (`SO_PEERCRED`): only a process owned by the same user may talk to the agent
+  (fail-closed). macOS/Windows peer authorization is planned; until then those
+  platforms rely on the `0600` socket permission.
+- **Memory hardening (Linux):** the agent disables core dumps and casual
+  ptrace/`/proc/<pid>/mem` access (`PR_SET_DUMPABLE=0`) and attempts to lock its
+  memory into RAM (`mlockall`) so secrets never reach swap. The memory lock needs
+  `CAP_IPC_LOCK` or a raised `RLIMIT_MEMLOCK` — the systemd unit below sets
+  `LimitMEMLOCK=infinity` to make it effective.
+- **Honest ceiling** (same as ssh-agent/gpg-agent): root, or a same-user process
+  that can still obtain ptrace, can read the agent's memory. This is strictly
+  better than a long-lived shell environment variable or a plaintext file.
+
+## Socket location
+
+Resolved in order:
+
+1. `$PASS_CLI_AGENT_SOCK` (explicit override)
+2. `$XDG_RUNTIME_DIR/pass-cli/agent.sock` (tmpfs; cleared on logout)
+3. `~/.pass-cli/agent.sock`
+
+## Snapshot freshness
+
+The agent holds an in-memory snapshot and takes **no exclusive lock**, so other
+`pass-cli` commands (`add`, `update`, …) keep working. Before serving, the agent
+revalidates against `vault.enc`: if a sibling process wrote it, the agent reloads
+so it never serves stale data. If the on-disk vault can no longer be decrypted with
+the held key (the master password was rotated elsewhere), the agent **locks** and
+fails the request rather than serving stale data. Changes pushed from **another
+machine** are not seen until the next unlock.
+
+## Running as a service (optional)
+
+Service managers are non-interactive, so **running the agent as a service requires
+keychain unlock** (`pass-cli keychain enable`) — otherwise the agent has no way to
+obtain the master password at startup. Templates (not auto-installed):
+
+- **Linux (systemd `--user`):** [`packaging/systemd/pass-cli-agent.service`](../../packaging/systemd/pass-cli-agent.service)
+  — sets `LimitMEMLOCK=infinity` so `mlockall` works, and stops at logout.
+- **macOS (launchd LaunchAgent):** [`packaging/launchd/com.reyamira.pass-cli.agent.plist`](../../packaging/launchd/com.reyamira.pass-cli.agent.plist)
+
+Windows is not yet supported (the agent uses a unix socket; a named-pipe transport
+is planned).

--- a/packaging/launchd/com.reyamira.pass-cli.agent.plist
+++ b/packaging/launchd/com.reyamira.pass-cli.agent.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  pass-cli background agent — launchd LaunchAgent (template, not auto-installed).
+
+  Install:
+    cp packaging/launchd/com.reyamira.pass-cli.agent.plist ~/Library/LaunchAgents/
+    # edit the ProgramArguments path below to your pass-cli binary
+    launchctl load ~/Library/LaunchAgents/com.reyamira.pass-cli.agent.plist
+
+  REQUIRES KEYCHAIN UNLOCK. A LaunchAgent has no terminal to prompt for the master
+  password, so set up keychain unlock (`pass-cli keychain enable`) first; otherwise
+  the agent cannot unlock at startup.
+
+  macOS memory hardening (mlock) is not yet implemented (planned); the agent runs
+  with its default posture on macOS.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.reyamira.pass-cli.agent</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/pass-cli</string>
+        <string>agent</string>
+        <string>--idle</string>
+        <string>15m</string>
+        <string>--max-ttl</string>
+        <string>8h</string>
+    </array>
+    <!-- Start at login; do not auto-restart on a clean auto-lock exit. -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+</dict>
+</plist>

--- a/packaging/systemd/pass-cli-agent.service
+++ b/packaging/systemd/pass-cli-agent.service
@@ -1,0 +1,33 @@
+# pass-cli background agent — systemd --user unit (template, not auto-installed).
+#
+# Install:
+#   mkdir -p ~/.config/systemd/user
+#   cp packaging/systemd/pass-cli-agent.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now pass-cli-agent
+#
+# REQUIRES KEYCHAIN UNLOCK. A service has no terminal to prompt for the master
+# password, so the vault must be set up for keychain unlock (`pass-cli keychain
+# enable`); otherwise the agent cannot unlock at startup and exits.
+#
+# LimitMEMLOCK=infinity lets the agent's mlockall() succeed (a Go runtime exceeds
+# the default 8 MB RLIMIT_MEMLOCK), so secrets are actually kept out of swap.
+
+[Unit]
+Description=pass-cli background credential agent
+Documentation=https://github.com/reyamira/pass-cli
+# Bind the agent's lifetime to the graphical/user session so it stops at logout.
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+# --idle/--max-ttl control auto-lock; tune to taste.
+ExecStart=%h/.local/bin/pass-cli agent --idle 15m --max-ttl 8h
+# Allow the agent to lock all its memory into RAM (no swap) — needed for mlockall.
+LimitMEMLOCK=infinity
+# Do not restart on a clean auto-lock/max-TTL exit; restart only on failure.
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target

--- a/plans/2026-06-30-daemon-and-env-injection-plan.md
+++ b/plans/2026-06-30-daemon-and-env-injection-plan.md
@@ -197,7 +197,10 @@ The agent unlocks via master-password prompt **or** `UnlockWithKeychain`. On mac
 
 ---
 
-## 6. Phase 3 — optional platform service
+## 6. Phase 3 — optional platform service — SHIPPED (templates + docs)
+Delivered as **run-on-demand + documented templates, not auto-registered**: `packaging/systemd/pass-cli-agent.service` (systemd `--user`, `LimitMEMLOCK=infinity` so 2d's `mlockall` is effective, stops at logout) and `packaging/launchd/com.reyamira.pass-cli.agent.plist`, plus `docs/05-operations/agent.md` documenting run-on-demand use, the security model, socket location, snapshot freshness, and the service templates. Both service paths require keychain unlock (a service is non-interactive). Windows waits on 2f. Socket-activation is a possible later nicety.
+
+### 6.1 Original notes
 
 Pure run-on-demand first (user runs `pass-cli agent`). Then optionally ship templates (not auto-installed):
 - **Linux:** `systemd --user` unit + socket activation (`pass-cli-agent.socket` → tmpfs path; systemd hands the listener fd, which also gives clean logout teardown).


### PR DESCRIPTION
Phase 3 of #116: the optional platform-service layer, shipped as documented templates (not auto-registered), plus a full operations guide for the agent.

> Plumbing/docs PR (auto-merge tier) — no Go changes.

## What is here
- **`packaging/systemd/pass-cli-agent.service`** — systemd `--user` unit. Sets `LimitMEMLOCK=infinity` so 2d's `mlockall` actually locks memory (a Go runtime exceeds the 8 MB default), binds to the graphical session so it stops at logout, and restarts only on failure (not on a clean auto-lock exit).
- **`packaging/launchd/com.reyamira.pass-cli.agent.plist`** — macOS LaunchAgent template.
- **`docs/05-operations/agent.md`** — run-on-demand usage, the security model (values-only protocol, `SO_PEERCRED`, `PR_SET_DUMPABLE`/`mlockall`, honest ceiling), socket location, snapshot freshness, and the service templates. Linked from the operations index.

## Notes
- Both service paths **require keychain unlock** (`pass-cli keychain enable`) — a service has no terminal to prompt for the master password. Documented prominently.
- Windows service waits on the 2f named-pipe transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)