### PR TITLE
fix(sync): failure-backoff so a dead remote isn't probed every command (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Agent revalidating cache** (#116) — a running `pass-cli agent` now reloads its in-memory vault snapshot when `vault.enc` changes on disk (e.g. another shell ran `add`/`update`), so it serves fresh data instead of a stale snapshot, without taking an exclusive lock that would block those other operations. If the on-disk vault can no longer be decrypted with the held key (the master password was rotated by another process), the agent locks and fails the request rather than serving stale data. The resolve path remains strictly read-only.
 - **Env-injection grammar: prefer `/` over `:`** (#115) — credential references now accept a slash separator (`service/field`) in addition to the legacy colon form (`service:field`, still accepted unchanged). Slash is preferred because in slash form a `:` inside a service name is a literal character, and it lines up with a future `op://`-style path. Applies to `--set` on both `exec` and `export`.
 
+### Fixed
+- **Sync: an unreachable remote no longer costs the probe timeout on every command** (#133) — the pre-unlock TTL-gate (#103) only opened on a *successful* probe, so with sync enabled and the remote down/slow every command re-probed and blocked for the full 8s (`Warning: failed to check remote state: … timed out after 8s`). A failed probe now stamps a failure timestamp and enters a backoff (the same window as `pull_ttl_seconds`, default 30s): subsequent commands skip the probe and serve the local vault, so a dead remote costs the timeout at most once per window. A successful contact clears the backoff immediately. To stay safe, a write during the backoff is **deferred** (not pushed) rather than blind-pushed — so a remote that recovered mid-window can't be silently overwritten — and syncs on the next command after the window expires.
+
 ## [0.18.0] - 2026-06-26
 
 ### Added

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,10 @@ type SyncConfig struct {
 	// PullTTLSeconds gates the pre-unlock remote probe: within this window a
 	// command serves the local vault without a remote round-trip (writes still do
 	// a fresh conflict check at push time). 0 uses the built-in default (30s); a
-	// negative value disables the gate (probe on every command).
+	// negative value disables the gate (probe on every command). The same window
+	// also doubles as the failure-backoff: after a probe fails (unreachable/slow
+	// remote) the next commands skip the probe until it expires, so a dead remote
+	// costs the probe timeout at most once per window instead of on every call.
 	PullTTLSeconds int `mapstructure:"pull_ttl_seconds"`
 }
 

--- a/internal/sync/state.go
+++ b/internal/sync/state.go
@@ -23,6 +23,13 @@ type SyncState struct {
 	// this is within the configured window, so a burst of commands makes one
 	// remote round-trip instead of one per command.
 	LastPullCheck time.Time `json:"last_pull_check"`
+	// LastPullFailure is when a metadata probe last failed (unreachable/slow
+	// remote). While this is within the backoff window the probe is skipped —
+	// so a dead remote costs the full probe timeout at most once per window
+	// instead of on every command (#133). A subsequent successful contact clears
+	// it (see stampSuccess). LastPullCheck (success) takes precedence when both
+	// are recent.
+	LastPullFailure time.Time `json:"last_pull_failure"`
 }
 
 // LoadState reads the sync state from the vault directory.

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -303,14 +303,22 @@ func (s *Service) SmartPull(vaultPath string) error {
 
 	vaultDir := filepath.Dir(vaultPath)
 
-	// TTL-gate: skip the remote probe if we contacted the remote recently.
+	// TTL-gate: skip the remote probe if we contacted the remote recently, OR if
+	// a recent probe failed (the failure-backoff — don't re-eat the probe timeout
+	// on a dead remote every call, #133). Either way the local vault is served and
+	// pullSkipped is set so a later SmartPush re-derives the right handling from
+	// state (conflict-check after a success-skip; defer after a failure-skip).
 	s.pullSkipped = false
 	if s.pullTTL > 0 {
-		if state, err := LoadState(vaultDir); err == nil &&
-			!state.LastPullCheck.IsZero() &&
-			time.Since(state.LastPullCheck) < s.pullTTL {
-			s.pullSkipped = true
-			return nil
+		if state, err := LoadState(vaultDir); err == nil {
+			if !state.LastPullCheck.IsZero() && time.Since(state.LastPullCheck) < s.pullTTL {
+				s.pullSkipped = true
+				return nil
+			}
+			if s.inFailureBackoff(state) {
+				s.pullSkipped = true
+				return nil
+			}
 		}
 	}
 
@@ -327,7 +335,11 @@ func (s *Service) pullFromRemote(vaultPath, vaultDir string) error {
 	remoteFiles, err := s.CheckRemoteMetadata()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to check remote state: %v\n", err)
-		return nil // Allow offline operation (do not stamp LastPullCheck)
+		// Allow offline operation. Stamp LastPullFailure (not LastPullCheck) so a
+		// dead/slow remote is re-probed at most once per backoff window instead of
+		// eating the full probe timeout on every command (#133).
+		s.recordPullFailure(vaultDir)
+		return nil
 	}
 
 	// Find vault.enc in remote files
@@ -417,10 +429,46 @@ func (s *Service) pullFromRemote(vaultPath, vaultDir string) error {
 // recordPullCheck stamps the TTL clock (LastPullCheck) and persists the state.
 // Called on every clean remote contact so the gate can skip subsequent probes.
 func (s *Service) recordPullCheck(vaultDir string, state *SyncState) {
-	state.LastPullCheck = time.Now()
+	stampSuccess(state)
 	if err := SaveState(vaultDir, state); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to save sync state: %v\n", err)
 	}
+}
+
+// stampSuccess marks a clean remote contact: it opens the TTL-gate
+// (LastPullCheck) and clears any prior failure timestamp so the failure-backoff
+// stops deferring pushes the moment the remote recovers (#133). Every place that
+// records a successful contact must go through here so a stale LastPullFailure
+// can never outlive a recovery.
+func stampSuccess(state *SyncState) {
+	state.LastPullCheck = time.Now()
+	state.LastPullFailure = time.Time{}
+}
+
+// recordPullFailure stamps LastPullFailure (probe timed out / remote
+// unreachable) and persists it, so the failure-backoff gate can skip re-probing
+// a dead remote until the window expires (#133). Best-effort: a save failure
+// only forfeits the backoff (the next command re-probes), never blocks.
+func (s *Service) recordPullFailure(vaultDir string) {
+	state, err := LoadState(vaultDir)
+	if err != nil {
+		state = &SyncState{}
+	}
+	state.LastPullFailure = time.Now()
+	if err := SaveState(vaultDir, state); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to save sync state: %v\n", err)
+	}
+}
+
+// inFailureBackoff reports whether a probe failed within the backoff window
+// (the same duration as pullTTL — one knob). While true, the pre-unlock pull
+// skips the probe (serving local) and SmartPush defers the push, so a dead or
+// slow remote is contacted at most once per window. Returns false when the gate
+// is disabled (pullTTL <= 0) or no failure is recorded.
+func (s *Service) inFailureBackoff(state *SyncState) bool {
+	return s.pullTTL > 0 &&
+		!state.LastPullFailure.IsZero() &&
+		time.Since(state.LastPullFailure) < s.pullTTL
 }
 
 // remoteChangedSinceLastPush probes the remote and reports whether it changed
@@ -493,6 +541,17 @@ func (s *Service) SmartPush(vaultPath string) (bool, error) {
 		return false, nil
 	}
 
+	// 3-pre. If a recent probe failed (failure-backoff active), the remote is
+	// down/slow. DEFER the push entirely — don't probe (which would re-eat the
+	// timeout) and don't push. The local change stays local and syncs on the next
+	// command after the backoff expires, when a fresh probe can conflict-check.
+	// Deferring rather than pushing is what keeps a remote that RECOVERED
+	// mid-backoff from being silently blind-overwritten by our stale-local push
+	// (#133).
+	if s.inFailureBackoff(state) {
+		return false, nil
+	}
+
 	// 3a. If the pre-unlock pull was TTL-skipped, it never checked the remote this
 	// cycle. Do a CONFLICT-ONLY check now, before pushing — never a pull, so it can
 	// never overwrite the local vault we are about to push. We are here because the
@@ -526,7 +585,7 @@ func (s *Service) SmartPush(vaultPath string) (bool, error) {
 	// remote, so stamp the TTL clock — the next command can skip its probe.
 	state.LastPushHash = localHash
 	state.LastPushTime = time.Now()
-	state.LastPullCheck = time.Now()
+	stampSuccess(state) // opens the TTL-gate and clears any stale failure-backoff
 
 	// Query actual remote metadata after push so next SmartPull sees current state.
 	// Using time.Now() would mismatch the provider's recorded ModTime.

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -781,3 +781,158 @@ func TestSmartPush_ConflictWhenPullSkippedFirstRunEmptyHash(t *testing.T) {
 		t.Errorf("SAFETY: expected 0 rclone RunNoOutput calls (no pull, no push), got %d", len(mock.runNoOutCalls))
 	}
 }
+
+// --- failure-backoff tests (#133) ---
+
+// TestSmartPull_StampsLastPullFailureOnProbeError verifies a failed probe stamps
+// LastPullFailure (and NOT LastPullCheck), so the backoff gate can skip the next
+// probe instead of re-eating the timeout.
+func TestSmartPull_StampsLastPullFailureOnProbeError(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	_ = os.WriteFile(vaultPath, []byte("vault-data"), 0600)
+
+	mock := &mockExecutor{runErr: errors.New("timed out after 8s")}
+	service := NewServiceWithExecutor(enabledConfig(), mock)
+	service.pullTTL = 30 * time.Second
+
+	if err := service.SmartPull(vaultPath); err != nil {
+		t.Fatalf("SmartPull should allow offline operation, got: %v", err)
+	}
+	st, err := LoadState(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if st.LastPullFailure.IsZero() {
+		t.Error("expected LastPullFailure to be stamped after a probe error")
+	}
+	if !st.LastPullCheck.IsZero() {
+		t.Error("expected LastPullCheck to remain zero after a probe error (only success stamps it)")
+	}
+}
+
+// TestSmartPull_FailureBackoffSkipsReprobe is the core #133 fix: with a recent
+// probe failure, SmartPull must skip the probe entirely (0 Run calls) rather than
+// re-eat the full probe timeout on every command.
+func TestSmartPull_FailureBackoffSkipsReprobe(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	_ = os.WriteFile(vaultPath, []byte("vault-data"), 0600)
+
+	_ = SaveState(tmpDir, &SyncState{LastPullFailure: time.Now()}) // just failed
+
+	mock := &mockExecutor{}
+	service := NewServiceWithExecutor(enabledConfig(), mock)
+	service.pullTTL = 30 * time.Second
+
+	if err := service.SmartPull(vaultPath); err != nil {
+		t.Fatalf("SmartPull returned error: %v", err)
+	}
+	if len(mock.runCalls) != 0 {
+		t.Errorf("expected 0 Run calls (probe skipped by failure-backoff), got %d", len(mock.runCalls))
+	}
+	if !service.pullSkipped {
+		t.Error("expected pullSkipped=true when the probe was failure-backoff-gated")
+	}
+}
+
+// TestSmartPull_FailureBackoffExpiredReprobes verifies the probe runs again once
+// the failure is outside the backoff window (so a recovered remote resyncs).
+func TestSmartPull_FailureBackoffExpiredReprobes(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	_ = os.WriteFile(vaultPath, []byte("vault-data"), 0600)
+
+	remoteTime := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	_ = SaveState(tmpDir, &SyncState{
+		LastPullFailure: time.Now().Add(-time.Hour), // stale failure
+		RemoteModTime:   remoteTime,
+		RemoteSize:      100,
+	})
+	lsjsonOutput, _ := json.Marshal([]RemoteFileInfo{{Name: "vault.enc", Size: 100, ModTime: remoteTime}})
+
+	mock := &mockExecutor{runOutput: lsjsonOutput}
+	service := NewServiceWithExecutor(enabledConfig(), mock)
+	service.pullTTL = 30 * time.Second
+
+	if err := service.SmartPull(vaultPath); err != nil {
+		t.Fatalf("SmartPull returned error: %v", err)
+	}
+	if len(mock.runCalls) != 1 {
+		t.Errorf("expected 1 Run call (probe, backoff expired), got %d", len(mock.runCalls))
+	}
+}
+
+// TestSmartPull_SuccessClearsFailure verifies a successful probe clears a prior
+// LastPullFailure so the failure-backoff stops deferring pushes on recovery.
+func TestSmartPull_SuccessClearsFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	_ = os.WriteFile(vaultPath, []byte("vault-data"), 0600)
+
+	remoteTime := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	_ = SaveState(tmpDir, &SyncState{
+		LastPullFailure: time.Now().Add(-time.Hour), // stale failure (outside backoff → reprobes)
+		RemoteModTime:   remoteTime,
+		RemoteSize:      100,
+	})
+	lsjsonOutput, _ := json.Marshal([]RemoteFileInfo{{Name: "vault.enc", Size: 100, ModTime: remoteTime}})
+
+	mock := &mockExecutor{runOutput: lsjsonOutput}
+	service := NewServiceWithExecutor(enabledConfig(), mock)
+	service.pullTTL = 30 * time.Second
+
+	if err := service.SmartPull(vaultPath); err != nil {
+		t.Fatalf("SmartPull returned error: %v", err)
+	}
+	st, err := LoadState(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if !st.LastPullFailure.IsZero() {
+		t.Error("expected LastPullFailure cleared after a successful probe")
+	}
+	if st.LastPullCheck.IsZero() {
+		t.Error("expected LastPullCheck stamped after a successful probe")
+	}
+}
+
+// TestSmartPush_DefersWhenFailureBackoffActive is the data-loss-safety test for
+// #133: when a recent probe failed, a changed local vault must NOT be probed or
+// pushed (deferred). Pushing here would blind-overwrite a remote that recovered
+// mid-backoff. LastPushHash must stay untouched so the change syncs next window.
+func TestSmartPush_DefersWhenFailureBackoffActive(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "vault.enc")
+	_ = os.WriteFile(vaultPath, []byte("local-modified"), 0600)
+
+	_ = SaveState(tmpDir, &SyncState{
+		LastPushHash:    "hash-before-local-edit", // local diverged
+		LastPullFailure: time.Now(),               // recent failure → backoff active
+	})
+
+	mock := &mockExecutor{}
+	service := NewServiceWithExecutor(enabledConfig(), mock)
+	service.pullTTL = 30 * time.Second
+
+	pushed, err := service.SmartPush(vaultPath)
+	if err != nil {
+		t.Fatalf("expected no error (deferred), got: %v", err)
+	}
+	if pushed {
+		t.Error("expected pushed=false (push deferred during failure-backoff)")
+	}
+	if len(mock.runCalls) != 0 {
+		t.Errorf("SAFETY: expected 0 Run calls (no probe during backoff), got %d", len(mock.runCalls))
+	}
+	if len(mock.runNoOutCalls) != 0 {
+		t.Errorf("SAFETY: expected 0 push calls (deferred, no blind overwrite), got %d", len(mock.runNoOutCalls))
+	}
+	st, err := LoadState(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if st.LastPushHash != "hash-before-local-edit" {
+		t.Errorf("expected LastPushHash untouched on defer, got %q", st.LastPushHash)
+	}
+}


### PR DESCRIPTION
Closes #133.

## Problem
The pre-unlock TTL-gate (#103) only stamped `LastPullCheck` on a **successful** probe. So with sync enabled and the rclone remote down/slow, every command re-probed and blocked for the full 8s probe timeout:

```
Warning: failed to check remote state: rclone lsjson failed: timed out after 8s
```

The gate that was supposed to skip re-probing never opened, because a dead remote never records a check.

## Fix (issue option 1 — the root cause)
A **failed** probe now stamps a separate `LastPullFailure` and enters a backoff (reusing the `pull_ttl_seconds` window, default 30s):

- `SmartPull` skips the probe while the backoff is active and serves the local vault → a dead remote costs the timeout **at most once per window** instead of every call.
- A successful contact clears the failure (`stampSuccess`), so recovery re-enables normal sync immediately.

## Data-loss safety (the important part)
A write during the backoff is **deferred, not pushed**. The advisor flagged the trap: the remote can recover *mid-window*, so "the remote is down, a push can't overwrite anything" is false. Blind-pushing (or letting `rclone sync` fail — which is *unbounded*, not 8s-capped) would silently overwrite a remote that another device updated during the window. Deferring keeps the local change local until the next command after the window expires, when a fresh probe can conflict-check. The existing success-skip path is unchanged (still does its push-time conflict check).

## Scope
- Reuses the existing `pull_ttl_seconds` knob as the backoff window (one knob, no new config).
- A configurable probe timeout (issue option 2) is left as a follow-up — a slow-but-alive remote (>8s) is treated as failed.

## Tests
5 new tests in `internal/sync/sync_test.go`:
- probe error stamps `LastPullFailure` (not `LastPullCheck`)
- backoff skips the re-probe (0 `Run` calls)
- backoff expiry re-probes
- success clears the failure
- **`SmartPush` defers** during backoff: 0 probe calls, 0 push calls, `LastPushHash` untouched

Full unit + integration suite green; `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)