### PR TITLE
fix(docs): repair broken links breaking the Pages deploy

### DIFF
--- a/docs/05-operations/agent.md
+++ b/docs/05-operations/agent.md
@@ -81,9 +81,9 @@ Service managers are non-interactive, so **running the agent as a service requir
 keychain unlock** (`pass-cli keychain enable`) — otherwise the agent has no way to
 obtain the master password at startup. Templates (not auto-installed):
 
-- **Linux (systemd `--user`):** [`packaging/systemd/pass-cli-agent.service`](../../packaging/systemd/pass-cli-agent.service)
+- **Linux (systemd `--user`):** [`packaging/systemd/pass-cli-agent.service`](https://github.com/reyamira/pass-cli/blob/main/packaging/systemd/pass-cli-agent.service)
   — sets `LimitMEMLOCK=infinity` so `mlockall` works, and stops at logout.
-- **macOS (launchd LaunchAgent):** [`packaging/launchd/com.reyamira.pass-cli.agent.plist`](../../packaging/launchd/com.reyamira.pass-cli.agent.plist)
+- **macOS (launchd LaunchAgent):** [`packaging/launchd/com.reyamira.pass-cli.agent.plist`](https://github.com/reyamira/pass-cli/blob/main/packaging/launchd/com.reyamira.pass-cli.agent.plist)
 
 Windows is not yet supported (the agent uses a unix socket; a named-pipe transport
 is planned).


### PR DESCRIPTION
## Problem

The **Deploy Docs to GitHub Pages** workflow has failed on every push to `main` since 2026-07-01 (5+ consecutive failures) — so the live docs site is stale as of 2026-06-27 and none of the recent docs (agent guide, #137/#138, v0.19.0 CHANGELOG + filter reference) are published.

Root cause: the Hugo site uses `contentDir: ../docs`, and `docs/05-operations/agent.md` links to the unit templates with `../../packaging/...`. Those paths resolve when browsing the repo on GitHub, but point **outside** the Hugo content root, so Hugo reports:

```
ERROR Broken internal link in 05-operations/agent.md: target '../../packaging/systemd/pass-cli-agent.service' not found
ERROR Broken internal link in 05-operations/agent.md: target '../../packaging/launchd/com.reyamira.pass-cli.agent.plist' not found
ERROR error building site: logged 2 error(s)
```

and exits 1.

## Fix

Point both links at absolute `github.com/reyamira/pass-cli/blob/main/...` URLs. Absolute URLs aren't subject to Hugo's internal-link resolution, and they resolve correctly for site visitors (the packaging files live at the repo root, outside the published site). Verified these were the only two out-of-content-root links in `docs/` (`grep -rE '\]\(\.\./\.\./' docs/`).

The **Validate Hugo Build** check on this PR runs the same Hugo build and will confirm the site builds. Once merged, the Pages deploy on `main` will succeed and publish the full docs backlog including v0.19.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)