### PR TITLE
feat(skills): ship version-matched agent guides via `pass-cli skills`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`skills` command — self-served, version-matched agent guides** — `pass-cli skills` ships an AI-agent usage guide embedded in the binary, mirroring the pattern that makes tools like agent-browser easy for agents to adopt: `pass-cli skills list` lists the available skills and `pass-cli skills get core` prints the safe-usage guide (`exec`/`export`/`inject`/`agent`/`list`/`get` plus the leak traps to avoid), with `--full` appending a complete command reference. Because the content ships *in the binary* (via `//go:embed`), the guidance always matches the installed version and can't drift from shipped behavior. `pass-cli skills install` writes a small discovery stub into a detected agent skills directory (`~/.claude/skills` or `~/.agents/skills`, or `--dir <path>`) that points agents at `pass-cli skills get core`; an existing, differing stub is preserved unless `--force` is given. This is the first step toward pass-cli being a first-class tool for humans **and** their AI agents.
+
 ## [0.19.0] - 2026-07-02
 
 ### Added

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -1,0 +1,225 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/arimxyer/pass-cli/internal/skills"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	skillsGetFull      bool
+	skillsInstallDir   string
+	skillsInstallForce bool
+)
+
+var skillsCmd = &cobra.Command{
+	Use:     "skills",
+	GroupID: "utilities",
+	Short:   "Agent-facing usage guides shipped with this binary",
+	Long: `Skills are version-matched usage guides for driving pass-cli as an AI
+agent. They ship embedded in this binary, so the guidance always matches the
+installed version and never goes stale.
+
+For AI agents: start with the core safe-usage guide.
+
+  pass-cli skills get core          # exec/export/inject/agent/list/get + leak traps
+  pass-cli skills get core --full   # also include the full command reference
+
+Run 'pass-cli skills install' to drop a small discovery stub into your agent's
+skills directory (e.g. ~/.claude/skills) that points back at this command.
+
+Examples:
+  # List available skills
+  pass-cli skills list
+
+  # Print the core agent guide
+  pass-cli skills get core
+
+  # Install the discovery stub for AI agents
+  pass-cli skills install`,
+	// No RunE: bare `pass-cli skills` prints help (its subcommands), matching
+	// the other parent commands (vault, config, keychain).
+}
+
+var skillsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available skills",
+	Args:  cobra.NoArgs,
+	RunE:  runSkillsList,
+}
+
+var skillsGetCmd = &cobra.Command{
+	Use:   "get <name>",
+	Short: "Print a skill's guide to stdout",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		content, err := skills.Get(args[0], skillsGetFull)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprint(cmd.OutOrStdout(), content)
+		return err
+	},
+}
+
+var skillsInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Write the agent discovery stub into a skills directory",
+	Long: `Install writes a small discovery stub (a Claude Code / agent skill) that
+points AI agents at 'pass-cli skills get core'. The stub is intentionally thin
+so it never goes stale; the real guidance is served by the CLI.
+
+By default the stub is written to the first existing of ~/.claude/skills or
+~/.agents/skills (falling back to creating ~/.claude/skills), as
+<dir>/pass-cli/SKILL.md. Use --dir to choose a different location.
+
+An existing stub that differs is left untouched unless --force is given.`,
+	Args: cobra.NoArgs,
+	RunE: runSkillsInstall,
+}
+
+func init() {
+	rootCmd.AddCommand(skillsCmd)
+	skillsCmd.AddCommand(skillsListCmd)
+	skillsCmd.AddCommand(skillsGetCmd)
+	skillsCmd.AddCommand(skillsInstallCmd)
+
+	skillsGetCmd.Flags().BoolVar(&skillsGetFull, "full", false, "include the full command reference")
+	skillsInstallCmd.Flags().StringVar(&skillsInstallDir, "dir", "", "skills directory to install into (default: auto-detect)")
+	skillsInstallCmd.Flags().BoolVar(&skillsInstallForce, "force", false, "overwrite an existing, differing stub")
+}
+
+func runSkillsList(cmd *cobra.Command, _ []string) error {
+	list, err := skills.List()
+	if err != nil {
+		return err
+	}
+	var sb strings.Builder
+	sb.WriteString("Available skills:\n")
+	tw := tabwriter.NewWriter(&sb, 0, 0, 2, ' ', 0)
+	for _, s := range list {
+		_, _ = fmt.Fprintf(tw, "  %s\t%s\n", s.Name, summaryLine(s.Description))
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	sb.WriteString("\nRun 'pass-cli skills get <name>' to print a guide (add --full for the command reference).\n")
+
+	_, err = fmt.Fprint(cmd.OutOrStdout(), sb.String())
+	return err
+}
+
+func runSkillsInstall(cmd *cobra.Command, _ []string) error {
+	dir, err := resolveSkillsDir(skillsInstallDir)
+	if err != nil {
+		return err
+	}
+	msg, err := installStub(dir, skillsInstallForce)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), msg)
+	return err
+}
+
+// installStub writes the discovery stub to <dir>/pass-cli/SKILL.md and returns a
+// human-readable status message. An existing stub that already matches is left
+// untouched (idempotent); an existing stub that differs is preserved unless
+// force is set. Kept separate from the Cobra command so the write behavior is
+// unit-testable against a temp dir.
+func installStub(dir string, force bool) (string, error) {
+	stub, err := skills.StubContent()
+	if err != nil {
+		return "", err
+	}
+	target := filepath.Join(dir, "pass-cli", "SKILL.md")
+
+	if existing, err := os.ReadFile(target); err == nil {
+		if string(existing) == stub {
+			return "Already up to date: " + target, nil
+		}
+		if !force {
+			return "", fmt.Errorf("a different stub already exists at %s; re-run with --force to overwrite", target)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return "", fmt.Errorf("failed to create %s: %w", filepath.Dir(target), err)
+	}
+	if err := os.WriteFile(target, []byte(stub), 0o644); err != nil {
+		return "", fmt.Errorf("failed to write %s: %w", target, err)
+	}
+
+	return "Installed discovery stub: " + target +
+		"\nAI agents will now be pointed at 'pass-cli skills get core'.", nil
+}
+
+// resolveSkillsDir picks the directory to install the stub into. An explicit
+// override is expanded and returned as-is; otherwise the first existing of
+// ~/.claude/skills or ~/.agents/skills is used, falling back to ~/.claude/skills.
+func resolveSkillsDir(override string) (string, error) {
+	if override != "" {
+		return expandHome(override), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	candidates := []string{
+		filepath.Join(home, ".claude", "skills"),
+		filepath.Join(home, ".agents", "skills"),
+	}
+	for _, c := range candidates {
+		if info, err := os.Stat(c); err == nil && info.IsDir() {
+			return c, nil
+		}
+	}
+	return candidates[0], nil
+}
+
+func expandHome(path string) string {
+	if path == "~" || len(path) >= 2 && path[:2] == "~/" {
+		if home, err := os.UserHomeDir(); err == nil {
+			if path == "~" {
+				return home
+			}
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}
+
+// summaryLine renders a skill's one-line summary for `skills list`. The
+// frontmatter description is written long and keyword-rich for AI-agent
+// discovery matching, so for the human list we take just its first sentence
+// (each description leads with a self-contained one), with a generous rune cap
+// as a backstop against a description that has no sentence break.
+func summaryLine(desc string) string {
+	desc = strings.TrimSpace(desc)
+	if i := strings.Index(desc, ". "); i >= 0 {
+		desc = desc[:i+1] // keep the period, drop the rest
+	}
+	return truncate(desc, 120)
+}
+
+// truncate shortens s to at most max runes (not bytes), appending an ellipsis
+// when it cuts. Rune-aware so a multi-byte character near the limit isn't split.
+func truncate(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max == 1 {
+		return string(runes[:1])
+	}
+	return string(runes[:max-1]) + "…"
+}

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/arimxyer/pass-cli/internal/skills"
+)
+
+func TestInstallStub(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "pass-cli", "SKILL.md")
+	stub, err := skills.StubContent()
+	if err != nil {
+		t.Fatalf("StubContent: %v", err)
+	}
+
+	// Fresh install writes the stub verbatim.
+	msg, err := installStub(dir, false)
+	if err != nil {
+		t.Fatalf("fresh install: %v", err)
+	}
+	if !strings.Contains(msg, "Installed discovery stub") {
+		t.Errorf("fresh install message = %q", msg)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading written stub: %v", err)
+	}
+	if string(got) != stub {
+		t.Error("written stub does not match StubContent()")
+	}
+
+	// Re-install with identical content is an idempotent no-op.
+	msg, err = installStub(dir, false)
+	if err != nil {
+		t.Fatalf("idempotent install: %v", err)
+	}
+	if !strings.Contains(msg, "Already up to date") {
+		t.Errorf("idempotent message = %q", msg)
+	}
+
+	// A differing existing stub is preserved unless --force.
+	if err := os.WriteFile(target, []byte("changed by user\n"), 0o644); err != nil {
+		t.Fatalf("mutating stub: %v", err)
+	}
+	if _, err := installStub(dir, false); err == nil {
+		t.Error("install without force overwrote a differing stub")
+	}
+	if kept, _ := os.ReadFile(target); string(kept) != "changed by user\n" {
+		t.Error("differing stub was clobbered despite no --force")
+	}
+
+	// --force overwrites it back to the canonical stub.
+	if _, err := installStub(dir, true); err != nil {
+		t.Fatalf("force install: %v", err)
+	}
+	if forced, _ := os.ReadFile(target); string(forced) != stub {
+		t.Error("--force did not restore the canonical stub")
+	}
+}
+
+func TestSummaryLine(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// First sentence only — no mid-word truncation.
+		{"Core guide for driving pass-cli safely. Read this before anything.", "Core guide for driving pass-cli safely."},
+		// No sentence break → returned as-is (within the cap).
+		{"A single clause with no period", "A single clause with no period"},
+		{"  leading/trailing space trimmed. rest ", "leading/trailing space trimmed."},
+	}
+	for _, c := range cases {
+		if got := summaryLine(c.in); got != c.want {
+			t.Errorf("summaryLine(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in   string
+		max  int
+		want string
+	}{
+		{"short", 100, "short"},
+		{"", 5, ""},
+		{"abcdef", 4, "abc…"},
+		{"abc", 3, "abc"},
+		{"abcd", 0, ""},
+		// Multi-byte runes must not be split mid-character.
+		{"héllo wörld", 5, "héll…"},
+	}
+	for _, c := range cases {
+		if got := truncate(c.in, c.max); got != c.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", c.in, c.max, got, c.want)
+		}
+	}
+}

--- a/docs/05-operations/_index.md
+++ b/docs/05-operations/_index.md
@@ -9,4 +9,5 @@ Operational guides for maintaining, monitoring, and securing pass-cli in product
   {{< card link="health-checks" title="Health Checks" icon="heart" subtitle="System diagnostics and vault health monitoring" >}}
   {{< card link="security-operations" title="Security Operations" icon="shield-exclamation" subtitle="Best practices, checklists, and incident response" >}}
   {{< card link="agent" title="Background Agent" icon="lightning-bolt" subtitle="Promptless, cached credential access via a local socket" >}}
+  {{< card link="agent-skills" title="AI Agent Skills" icon="sparkles" subtitle="Version-matched agent usage guides served by the CLI" >}}
 {{< /cards >}}

--- a/docs/05-operations/agent-skills.md
+++ b/docs/05-operations/agent-skills.md
@@ -1,0 +1,45 @@
+---
+title: "AI Agent Skills"
+weight: 4
+toc: true
+---
+
+pass-cli ships an **agent usage guide inside the binary**. Any AI agent (Claude
+Code, Cursor, Codex, …) driving pass-cli can load version-matched guidance
+straight from the CLI, so the instructions never drift from the installed
+version.
+
+## For agents: start here
+
+```sh
+pass-cli skills get core          # safe-usage guide: exec/export/inject/agent/list/get + leak traps
+pass-cli skills get core --full   # also include the full command reference
+pass-cli skills list              # list every skill shipped with this version
+```
+
+`skills get core` is the entry point. It explains the one rule that matters —
+**never let a secret value land in the transcript, a log, or a watched file** —
+and which command to reach for (`exec` by default; `inject` for composite
+secrets; `list -q` to discover services; `get` only as a last resort).
+
+## Installing the discovery stub
+
+`skills install` drops a small skill file into your agent's skills directory so
+the agent discovers pass-cli automatically and is pointed at `skills get core`:
+
+```sh
+pass-cli skills install                 # auto-detects ~/.claude/skills or ~/.agents/skills
+pass-cli skills install --dir <path>    # choose a specific directory
+pass-cli skills install --force         # overwrite an existing, differing stub
+```
+
+The stub is intentionally thin — the real, version-matched guidance stays in the
+binary. Re-running `skills install` after upgrading pass-cli is safe (it's a
+no-op when the stub is already current).
+
+## Why embedded, not a static doc
+
+The skill content is compiled into the binary via `//go:embed`, so it's always
+in lockstep with the commands and flags that binary actually has. A stale copy
+pasted into a project's docs or a user's dotfiles can't drift out of sync,
+because agents read the guide from the CLI itself.

--- a/internal/skills/data/skills/core.full.md
+++ b/internal/skills/data/skills/core.full.md
@@ -1,0 +1,131 @@
+## Full command reference
+
+Condensed flag reference for the agent-facing commands. `pass-cli <cmd> --help`
+always has the authoritative, version-matched detail.
+
+### Mapping grammar (shared by `exec` and `export`)
+
+```
+--set ENV_NAME=service[/field][|filter]      # repeatable
+```
+
+- `service` — the credential's service name.
+- `/field` — one of `username, password, category, url, notes, service`
+  (default `password`). Legacy `:field` also accepted; prefer `/`.
+- `|filter` — one of `base64`, `base64url`, `basicauth` (quote the `|` in a
+  shell). `basicauth` takes no field.
+- Convenience positional form: `pass-cli exec service …` derives the ENV name
+  from the service (uppercased, non-alphanumerics → `_`). Filters are **not**
+  supported on this form.
+
+### `exec` — run a command with injected env
+
+| Flag | Meaning |
+|---|---|
+| `--set ENV=service[/field][\|filter]` | map an env var to a credential (repeatable) |
+| `-f, --field <field>` | field for all `--set` mappings (default `password`) |
+| `--env-file <file>` | read `KEY=${pass:svc/field}` template lines (repeatable) |
+| `--from <file>` | read `ENV=service/field` from a `.pass-cli.toml` manifest (repeatable) |
+
+Everything after `--` is the child command; its exit code is propagated.
+Read-only: no usage tracking, no sync push.
+
+### `export` — print shell statements to eval
+
+| Flag | Meaning |
+|---|---|
+| `--set`, `-f/--field`, `--from` | same as `exec` |
+| `--format <sh\|fish\|powershell>` | shell syntax (default `sh`) |
+
+`sh` → `export NAME='value'` (for `eval "$(…)"`); `fish` → `set -gx NAME 'value'`
+(for `… | source`); `powershell` → `$env:NAME = 'value'`.
+
+### `inject` — render a template with `${pass:...}` refs
+
+| Flag | Meaning |
+|---|---|
+| `-i, --in-file <file>` | template to read (default stdin) |
+| `-o, --out-file <file>` | output file, created `0600` (default stdout) |
+| `-f, --field <field>` | default field for refs without an explicit `/field` |
+
+Reference forms: `${pass:service}`, `${pass:service/field}`,
+`${pass:service/field | filter}`. Unknown/malformed ref → hard error, nothing
+written. Piped-stdin templates unlock via keychain only (use `-i` for the
+password prompt).
+
+### `agent` — background daemon holding the unlocked vault
+
+| Subcommand | Meaning |
+|---|---|
+| `agent start` | unlock once, detach into the background |
+| `agent serve` | run in the foreground (same as bare `agent`) |
+| `agent status` | show status (never prints secrets) |
+| `agent stop` | lock the vault and exit |
+
+| Flag | Meaning |
+|---|---|
+| `--idle <dur>` | lock after this much inactivity (default `15m`, `0` = never) |
+| `--max-ttl <dur>` | hard cap on unlocked lifetime (default `8h`, `0` = no cap) |
+
+Socket: `$PASS_CLI_AGENT_SOCK`, else `$XDG_RUNTIME_DIR/pass-cli/agent.sock`, else
+`~/.pass-cli/agent.sock`. Serves resolved **values only**. Commands fall back to
+direct unlock when no agent is running.
+
+### `list` — discover services
+
+| Flag | Meaning |
+|---|---|
+| `-q, --quiet` | bare service names, one per line (alias for `--format simple`) |
+| `-f, --format <table\|json\|simple>` | output format (default `table`) |
+| `--show-usernames` | include the username column (hidden by default) |
+| `--unused [--days N]` | only credentials unused for ≥ N days (default 30) |
+| `--by-project` | group by git repository |
+| `--location <dir> [--recursive]` | filter by access directory |
+
+Usernames hidden by default (they can hold sensitive values). `--format json`
+emits full metadata including usernames.
+
+### `get` — retrieve one credential (last resort for raw values)
+
+| Flag | Meaning |
+|---|---|
+| `-q, --quiet` | output only the requested value (script-friendly) |
+| `-f, --field <field>` | field to extract (default `password`) |
+| `--no-clipboard` | do not copy to clipboard |
+| `--masked` | display password as asterisks |
+| `--totp` / `--totp-qr` / `--totp-qr-file <png>` | TOTP code / QR |
+
+Even with `--quiet --no-clipboard` the value is on stdout — see the leak trap in
+the core guide. Prefer `exec`.
+
+### `generate` — cryptographically secure password
+
+| Flag | Meaning |
+|---|---|
+| `-l, --length N` | length (default 20) |
+| `--no-lower` / `--no-upper` / `--no-digits` / `--no-symbols` | exclude a class |
+| `--no-clipboard` | do not copy to clipboard |
+
+Aliases: `gen`, `pwd`.
+
+### `.pass-cli.toml` manifest (for `--from`)
+
+A committable file — references only, never values:
+
+```toml
+[env]
+GITHUB_TOKEN = "github"
+DB_PASSWORD  = "postgres/password"
+API_TOKEN    = "api/token|base64"
+```
+
+`pass-cli exec --from .pass-cli.toml -- ./server` or
+`eval "$(pass-cli export --from .pass-cli.toml)"`.
+
+### Global flags (all commands)
+
+| Flag | Meaning |
+|---|---|
+| `--config <file>` | config file (default `$HOME/.pass-cli/config.yaml`) |
+| `--offline` | skip cloud sync for this command |
+| `-v, --verbose` | verbose output |

--- a/internal/skills/data/skills/core.md
+++ b/internal/skills/data/skills/core.md
@@ -1,0 +1,239 @@
+---
+name: core
+description: Core guide for driving pass-cli safely as an AI agent. Read this before running any pass-cli command that touches a secret. Covers the decision between exec/export/inject/list/get, the env-injection grammar (--set, --field, service/field, value filters base64/base64url/basicauth, --env-file, --from manifest), the background agent daemon for promptless resolves, and the leak traps to avoid so a secret never lands in the transcript, logs, or a watched file.
+---
+
+# Using pass-cli safely as an agent
+
+pass-cli is a local, offline-first password manager. Its vault is a single
+AES-GCM-encrypted file. As an agent you will mostly need it to **give a stored
+secret to a command you're about to run** — and the cardinal rule is:
+
+> **Never let a secret value land in the transcript, a log, CI output, or any
+> file a tool watches.** Once a secret is in the conversation log on disk it is
+> compromised and must be rotated.
+
+Every command below exists to move a secret from the vault into a consumer
+**without it passing through stdout, the clipboard, your shell history, or a
+`set -x` trace.**
+
+## The decision: how do you need the secret?
+
+| You need to… | Use | Why |
+|---|---|---|
+| Run a command that reads the secret from its environment | **`exec`** | Secret goes straight into the child's env; scoped to that one process; nothing on stdout |
+| Load a secret into your *current* shell (last resort for env) | `export` | Weaker than `exec` — the whole shell + its children can read it |
+| Build a config file / connection string that *embeds* a secret | **`inject`** | Templating: `${pass:svc/field}` references get replaced; the only tool for composite/derived secrets |
+| Know *which* services exist | **`list -q`** | Bare service names; usernames hidden by default |
+| Capture a raw value into a variable (last resort) | `get --quiet --no-clipboard` | Only when nothing else can express it; see the trap below |
+
+**Default to `exec`.** Reach for `export`/`inject` only when `exec` can't express
+the shape, and `get` only when nothing else works.
+
+If an agent will do **many** lookups in a session, start the **agent daemon**
+once (see below) so every `exec`/`export`/`inject` resolves with no
+master-password prompt.
+
+## `exec` — hand a secret to a command (the default)
+
+Runs a child command with credentials injected as environment variables. The
+value is passed **only** through the child's environment — never a file, the
+clipboard, or shell history. pass-cli writes nothing of its own to stdout, and
+the child's exit code is propagated unchanged.
+
+```bash
+# Explicit mapping (repeatable): --set ENV_NAME=service
+pass-cli exec --set GITHUB_TOKEN=github -- gh repo list
+
+# Multiple credentials at once
+pass-cli exec --set AWS_ACCESS_KEY_ID=aws-id --set AWS_SECRET_ACCESS_KEY=aws-secret -- aws s3 ls
+
+# Pick a non-password field for ALL mappings with -f/--field
+pass-cli exec --set DB_USER=postgres --field username -- ./run-migration.sh
+
+# Per-mapping field with service/field (overrides -f for that one entry)
+pass-cli exec --set DB_USER=postgres/username --set DB_PASSWORD=postgres/password -- ./run.sh
+
+# Convenience form: derive ENV name from the service (openai-api -> OPENAI_API)
+pass-cli exec openai-api -- python train.py
+```
+
+Key facts:
+- **`--`** separates pass-cli's flags from the child command. Everything after
+  `--` is the child's argv. Omitting it is an error ("no command to run").
+- **`-f/--field`** (default `password`) selects the field for *all* `--set`
+  mappings. Valid fields: `username, password, category, url, notes, service`.
+- **`service/field`** in a `--set` overrides `-f` for that single mapping. The
+  legacy `service:field` separator still works, but prefer `/` — in slash form
+  any `:` in the service name is a literal character.
+- **Exit code is propagated** — `pass-cli exec … -- sh -c 'exit 7'` exits 7.
+  Safe in `&&`/`||` chains and CI gates.
+- **`exec` is read-only**: it does NOT record field-access usage and does NOT
+  trigger a sync push, so calling it in a hot loop won't mutate the vault or hit
+  the network on every run.
+- **Two more mapping sources** for composite/committed setups (compose with
+  `--set`):
+  - `--env-file <file>` — lines of `KEY=<template>` whose values may embed
+    `${pass:service/field}` references (same templating as `inject`). Resolves
+    values a plain `ENV=service` mapping can't, e.g.
+    `DATABASE_URL=postgres://app:${pass:db/password}@localhost/app`.
+  - `--from .pass-cli.toml` — a committable manifest whose `[env]` table maps
+    `ENV_NAME = "service/field"` (references only, never values), so a launcher
+    or `.envrc` needn't repeat long `--set` chains.
+- **Honest limit:** the value lives in the child's environment — readable via
+  `/proc/<pid>/environ` by the same user and inherited by descendants. This is
+  the same model as `op run` / `aws-vault exec`: far safer than files,
+  clipboards, or history, but it is not process isolation.
+
+## `export` — load secrets into the current shell (weaker than `exec`)
+
+Prints shell statements for your shell to evaluate. Same mapping grammar as
+`exec` (`--set`, `-f`, `service/field`, `--from`).
+
+```bash
+eval "$(pass-cli export --set GITHUB_TOKEN=github)"     # sh/bash/zsh
+pass-cli export --set GITHUB_TOKEN=github --format fish | source
+pass-cli export --format powershell --set GITHUB_TOKEN=github | iex
+```
+
+`--format` is `sh` (default), `fish`, or `powershell`. **Prefer `exec`:**
+`export` materializes the secret into your current shell for its whole lifetime
+(and every process it launches can read it). Use `export` as the blessed
+replacement for `VAR="$(pass-cli get …)"`, *not* as a replacement for `exec`.
+
+## `inject` — materialize secrets embedded in text (composite secrets)
+
+Reads a template and writes it back with every `${pass:service/field}` reference
+replaced by the credential's value. This is the tool for a whole config file or
+a single connection string — anything where the secret is *embedded* in other
+text.
+
+```bash
+# A connection string with an embedded secret
+echo 'postgres://app:${pass:db/password}@localhost/app' | pass-cli inject
+
+# A whole config file (references only in the committed template)
+pass-cli inject -i config.tmpl -o config.ini
+```
+
+Reference syntax:
+- `${pass:service}` — the service's default field (see `-f/--field`).
+- `${pass:service/field}` — a specific field.
+- `${pass:service/field | filter}` — apply a **value filter** (see below).
+
+Only `${pass:...}` is special; `$VAR`, `${VAR}`, and `$(...)` pass through
+untouched. An unknown or malformed reference — including an unknown filter — is
+a **hard error and nothing is written** (fail-closed).
+
+Caveats:
+- **Piped-on-stdin templates unlock via the OS keychain only** — the master-
+  password prompt also reads stdin, so it would consume the piped template. Use
+  `-i/--in-file` if you need the interactive password prompt.
+- **The rendered output is plaintext secrets.** `-o/--out-file` is created
+  `0600`; writing to stdout puts the secret on your terminal/pipe. Prefer `exec`
+  when you can; use `inject` for the composite/derived cases `exec` can't express.
+
+### Value filters (base64 / base64url / basicauth)
+
+A reference (or a `--set`/manifest mapping) can carry one trailing `| filter`.
+Filters transform the value *before* it's injected, so you never have to pipe a
+secret through an external `base64` (which would put it on stdout):
+
+- `base64` — standard base64 of the value (e.g. a Bearer token).
+- `base64url` — URL-safe base64.
+- `basicauth` — `base64("username:password")` from a single credential (takes
+  no field; it uses that credential's own username + password).
+
+```bash
+# Authorization: Basic header from one credential's user:password
+echo 'Authorization: Basic ${pass:api | basicauth}' | pass-cli inject
+
+# base64 a token in a --set mapping (quote the '|' so the shell doesn't pipe)
+pass-cli exec --set 'TOKEN=api/token|base64' -- ./server
+```
+
+Filters work on `--set`, the `--from` manifest, and `${pass:...}` templates.
+They are **not** supported on the positional convenience form
+(`pass-cli exec service …`). One filter per reference; case-sensitive
+(`base64`, not `BASE64`).
+
+## `agent` — unlock once, resolve promptlessly (for busy sessions)
+
+The background agent unlocks the vault once and holds it in memory, then answers
+read-only lookups over a local socket so `exec`/`export`/`inject` need **no
+master-password prompt and no key derivation** on each call.
+
+```bash
+pass-cli agent start                 # unlock once, detach into the background
+pass-cli exec --set T=github -- gh repo list   # resolves via the agent, no prompt
+pass-cli agent status                # never prints secrets
+pass-cli agent stop                  # locks the vault and exits
+```
+
+- Serves resolved field **values only** — the master password and derived key
+  never leave the agent process.
+- Auto-locks after `--idle` inactivity (default 15m) and always after
+  `--max-ttl` (default 8h); locks + exits on SIGINT/SIGTERM.
+- **Transparent fallback:** when no agent is running, every command opens and
+  unlocks the vault directly, so scripts work either way.
+
+Start the agent at the top of a session where you'll resolve many credentials;
+otherwise the direct-unlock path is fine.
+
+## `list` — listing is the *safe* step
+
+```bash
+pass-cli list            # default table: NO username column (usernames can be sensitive)
+pass-cli list -q         # bare service names, one per line — ideal for agents/scripts
+pass-cli list --show-usernames   # opt the username column back in (only if you need it)
+pass-cli list --format json      # full metadata incl. usernames — explicit, structured opt-in
+```
+
+Usernames are **hidden by default** because that field often holds sensitive
+values (card/account/routing numbers stored as an entry's "username"). Use
+`pass-cli list -q` to discover service names without dumping anything sensitive.
+
+## `get` — last resort, and the trap
+
+```bash
+pass-cli get github --quiet --no-clipboard --field password
+```
+
+`--quiet` prints **only** the field value to stdout; `--no-clipboard` skips the
+clipboard. But this still puts the secret on stdout — and the trap is what you do
+with it next:
+
+```bash
+# ❌ NEVER — the value is now in the transcript / log
+echo "$(pass-cli get github --quiet --no-clipboard)"
+TOKEN=$(pass-cli get github --quiet --no-clipboard); curl -H "Authorization: $TOKEN" ...
+#   ^ if any layer runs `set -x`, or a file-watcher captures the command, the token leaks
+
+# ✅ Prefer exec — the value never becomes a shell variable or a transcript line
+pass-cli exec --set TOKEN=github -- sh -c 'curl -H "Authorization: Bearer $TOKEN" ...'
+#   (the child reads $TOKEN from its own env; pass-cli printed nothing)
+```
+
+If you genuinely must capture into a variable (a tool with no env-var path),
+pipe it directly into the consumer in the **same** command, never `echo` it, and
+never enable shell tracing in that shell.
+
+## Leak-trap checklist (before you run anything)
+
+- Am I about to `echo`/print a secret, or interpolate it into a logged command?
+  → use `exec`.
+- Is `set -x` / xtrace active in this shell? → a `get`/substitution will dump the
+  value. Disable it or use `exec`.
+- Am I writing the secret into a `.env*` or any file a tool watches? → the
+  harness echoes file changes; don't. Use `exec`, or `inject -o` to a `0600`
+  file the harness doesn't watch.
+- Do I just need to *see what's stored*? → `pass-cli list -q` (names only).
+
+If a secret value ever does reach the transcript: tell the user immediately so
+they can rotate it. The leak cannot be undone.
+
+---
+
+Run `pass-cli skills get core --full` for a condensed flag reference of every
+agent-facing command, the mapping grammar, and the `.pass-cli.toml` manifest
+format.

--- a/internal/skills/data/stub.md
+++ b/internal/skills/data/stub.md
@@ -1,0 +1,39 @@
+---
+name: pass-cli
+description: How an AI agent should safely drive the pass-cli password manager. Use whenever a task needs a stored secret/credential to run a command, when reading from or listing a pass-cli vault, or when you're about to capture a secret with `get` or command substitution — there is a safer path. pass-cli can hand a secret to a child process without it ever touching stdout (exec), materialize composite secrets into config files (inject), and serve promptless resolves from a background agent. Triggers include "run this with my API key", "use my stored token", "inject a secret into this config", "list my credentials", or any task that needs a value out of the pass-cli vault.
+allowed-tools: Bash(pass-cli:*)
+hidden: true
+---
+
+# pass-cli
+
+Local, offline-first password manager for humans and their AI agents. The vault
+is a single AES-GCM-encrypted file.
+
+## Start here
+
+This file is a discovery stub, not the usage guide. Before running any
+`pass-cli` command that touches a secret, load the actual guide from the CLI:
+
+```bash
+pass-cli skills get core          # the safe-usage guide: exec/export/inject/agent/list/get + leak traps
+pass-cli skills get core --full   # also include the full command reference
+```
+
+The CLI serves skill content that always matches the installed version, so the
+guidance never goes stale. The content in this stub cannot change between
+releases, which is why it just points at `skills get core`.
+
+## The one rule you must not break
+
+**Never let a secret value land in the transcript, a log, CI output, or any file
+a tool watches.** Prefer `pass-cli exec --set ENV=service -- <command>`: the
+secret goes straight into the child's environment and never touches stdout, the
+clipboard, or your shell history. If a secret ever does reach the transcript,
+tell the user immediately so they can rotate it.
+
+## List available skills
+
+```bash
+pass-cli skills list              # every skill shipped with the installed version
+```

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -1,0 +1,148 @@
+// Package skills serves version-matched, agent-facing usage guides embedded in
+// the pass-cli binary. The embedded markdown is the single source of truth for
+// how an AI agent should drive pass-cli; the `pass-cli skills` command is a thin
+// wrapper over the accessors here, and `skills install` writes a discovery stub
+// (StubContent) into an agent's skills directory that just points back at
+// `pass-cli skills get core`.
+package skills
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+)
+
+//go:embed all:data
+var dataFS embed.FS
+
+const (
+	skillsDir = "data/skills"
+	stubPath  = "data/stub.md"
+	mdExt     = ".md"
+	fullExt   = ".full.md"
+)
+
+// Skill is a listable skill: its name and the description parsed from the
+// markdown file's frontmatter.
+type Skill struct {
+	Name        string
+	Description string
+}
+
+// List returns every listable skill (a `<name>.md` file, excluding the
+// `<name>.full.md` companions), sorted by name. The description comes from each
+// file's frontmatter.
+func List() ([]Skill, error) {
+	entries, err := fs.ReadDir(dataFS, skillsDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read embedded skills: %w", err)
+	}
+
+	var out []Skill
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, mdExt) || strings.HasSuffix(name, fullExt) {
+			continue
+		}
+		body, err := fs.ReadFile(dataFS, skillsDir+"/"+name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read embedded skill %q: %w", name, err)
+		}
+		fm, _ := splitFrontmatter(string(body))
+		out = append(out, Skill{
+			Name:        strings.TrimSuffix(name, mdExt),
+			Description: fm["description"],
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// Get returns the body of a skill (frontmatter stripped). When full is true and
+// a `<name>.full.md` companion exists, it is appended. An unknown name returns
+// an error that lists the valid names.
+func Get(name string, full bool) (string, error) {
+	body, err := fs.ReadFile(dataFS, skillsDir+"/"+name+mdExt)
+	if err != nil {
+		return "", unknownSkillError(name)
+	}
+	_, content := splitFrontmatter(string(body))
+	out := strings.Trim(content, "\n")
+
+	if full {
+		if extra, err := fs.ReadFile(dataFS, skillsDir+"/"+name+fullExt); err == nil {
+			_, extraContent := splitFrontmatter(string(extra))
+			out += "\n\n" + strings.Trim(extraContent, "\n")
+		}
+	}
+
+	return out + "\n", nil
+}
+
+// StubContent returns the discovery-stub markdown written by `skills install`.
+func StubContent() (string, error) {
+	b, err := fs.ReadFile(dataFS, stubPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read embedded stub: %w", err)
+	}
+	return string(b), nil
+}
+
+func unknownSkillError(name string) error {
+	list, err := List()
+	if err != nil {
+		return fmt.Errorf("unknown skill %q", name)
+	}
+	names := make([]string, len(list))
+	for i, s := range list {
+		names[i] = s.Name
+	}
+	return fmt.Errorf("unknown skill %q; available: %s", name, strings.Join(names, ", "))
+}
+
+// splitFrontmatter separates a leading `---`-delimited YAML frontmatter block
+// from the markdown body. It returns the parsed frontmatter fields (only simple
+// single-line `key: value` pairs are recognized) and the remaining body. When
+// there is no frontmatter, the fields map is empty and the whole input is the
+// body.
+func splitFrontmatter(s string) (map[string]string, string) {
+	fields := map[string]string{}
+
+	// Normalize CRLF so the delimiter check is newline-agnostic.
+	norm := strings.ReplaceAll(s, "\r\n", "\n")
+	if !strings.HasPrefix(norm, "---\n") {
+		return fields, s
+	}
+
+	rest := norm[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		// No closing delimiter — treat the whole thing as body.
+		return fields, s
+	}
+
+	block := rest[:end]
+	for _, line := range strings.Split(block, "\n") {
+		key, val, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
+		val = strings.Trim(val, `"'`)
+		if key != "" {
+			fields[key] = val
+		}
+	}
+
+	// Body starts after the closing "---" line.
+	body := rest[end+len("\n---"):]
+	body = strings.TrimPrefix(body, "\n")
+	return fields, body
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,0 +1,141 @@
+package skills
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestListReturnsCore(t *testing.T) {
+	list, err := List()
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatal("List() returned no skills")
+	}
+
+	var core *Skill
+	for i := range list {
+		if list[i].Name == "core" {
+			core = &list[i]
+		}
+	}
+	if core == nil {
+		t.Fatal("List() did not include the 'core' skill")
+	}
+	if strings.TrimSpace(core.Description) == "" {
+		t.Error("core skill has an empty description (frontmatter not parsed?)")
+	}
+}
+
+// Every listed skill must be retrievable both plain and --full, with non-empty
+// content — guards against a dangling list entry or a broken embed.
+func TestEveryListedSkillIsRetrievable(t *testing.T) {
+	list, err := List()
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	for _, s := range list {
+		if strings.TrimSpace(s.Name) == "" {
+			t.Error("skill with empty name in List()")
+			continue
+		}
+		plain, err := Get(s.Name, false)
+		if err != nil {
+			t.Errorf("Get(%q, false) error: %v", s.Name, err)
+			continue
+		}
+		if strings.TrimSpace(plain) == "" {
+			t.Errorf("Get(%q, false) returned empty content", s.Name)
+		}
+		full, err := Get(s.Name, true)
+		if err != nil {
+			t.Errorf("Get(%q, true) error: %v", s.Name, err)
+			continue
+		}
+		// --full must be a superset of the plain body.
+		if !strings.HasPrefix(full, strings.TrimRight(plain, "\n")) {
+			t.Errorf("Get(%q, true) does not start with the plain body", s.Name)
+		}
+	}
+}
+
+func TestCoreFullIsLongerAndContainsBase(t *testing.T) {
+	plain, err := Get("core", false)
+	if err != nil {
+		t.Fatalf("Get(core,false) error: %v", err)
+	}
+	full, err := Get("core", true)
+	if err != nil {
+		t.Fatalf("Get(core,true) error: %v", err)
+	}
+	if len(full) <= len(plain) {
+		t.Errorf("core --full (%d bytes) is not longer than plain (%d bytes)", len(full), len(plain))
+	}
+	if !strings.Contains(full, "Full command reference") {
+		t.Error("core --full is missing the command reference section")
+	}
+}
+
+func TestGetStripsFrontmatter(t *testing.T) {
+	body, err := Get("core", false)
+	if err != nil {
+		t.Fatalf("Get(core,false) error: %v", err)
+	}
+	if strings.HasPrefix(body, "---") {
+		t.Error("Get() did not strip the leading frontmatter block")
+	}
+	if strings.Contains(body, "description:") {
+		t.Error("Get() leaked a frontmatter field into the body")
+	}
+}
+
+func TestGetUnknownSkillErrors(t *testing.T) {
+	_, err := Get("does-not-exist", false)
+	if err == nil {
+		t.Fatal("Get() on an unknown skill did not error")
+	}
+	if !strings.Contains(err.Error(), "core") {
+		t.Errorf("unknown-skill error should list valid names; got: %v", err)
+	}
+}
+
+func TestStubContent(t *testing.T) {
+	stub, err := StubContent()
+	if err != nil {
+		t.Fatalf("StubContent() error: %v", err)
+	}
+	if strings.TrimSpace(stub) == "" {
+		t.Fatal("StubContent() is empty")
+	}
+	for _, want := range []string{
+		"pass-cli skills get core",
+		"allowed-tools: Bash(pass-cli:*)",
+	} {
+		if !strings.Contains(stub, want) {
+			t.Errorf("StubContent() missing %q", want)
+		}
+	}
+}
+
+func TestSplitFrontmatter(t *testing.T) {
+	fields, body := splitFrontmatter("---\nname: x\ndescription: \"hi there\"\n---\n# Body\ntext\n")
+	if fields["name"] != "x" {
+		t.Errorf("name = %q, want x", fields["name"])
+	}
+	if fields["description"] != "hi there" {
+		t.Errorf("description = %q, want 'hi there'", fields["description"])
+	}
+	if !strings.HasPrefix(body, "# Body") {
+		t.Errorf("body = %q, want it to start with '# Body'", body)
+	}
+
+	// No frontmatter → whole input is the body.
+	fields2, body2 := splitFrontmatter("# Just a heading\n")
+	if len(fields2) != 0 {
+		t.Errorf("expected no fields, got %v", fields2)
+	}
+	if body2 != "# Just a heading\n" {
+		t.Errorf("body2 = %q", body2)
+	}
+}


### PR DESCRIPTION
## What & why

pass-cli is evolving into a tool for humans **and** their AI agents, but the only agent-facing usage guidance lived in a hand-written personal skill on one machine — stale, unversioned, invisible to anyone else.

This adopts the **agent-browser pattern**: the CLI self-serves its own skills, **embedded in the binary via `//go:embed`**, so the guidance always matches the installed version and can't drift from shipped behavior.

## What's new

- **`pass-cli skills list`** (or bare `pass-cli skills`) — lists available skills with descriptions.
- **`pass-cli skills get core`** — the canonical agent safe-usage guide, **rewritten against the current binary**: `exec` (default) / `export` / `inject` / the `agent` daemon / `list -q` / `get`, the env-injection grammar, the v0.19.0 `base64`/`base64url`/`basicauth` filters, and the leak-trap checklist. `--full` appends a complete command reference.
- **`pass-cli skills install [--dir <path>] [--force]`** — writes a thin discovery stub into a detected agent skills dir (`~/.claude/skills` → `~/.agents/skills`) pointing agents at `skills get core`. Idempotent; refuses to clobber a differing existing stub without `--force`.

## Design

- **Single source of truth:** `internal/skills` (the repo's first `//go:embed`) is canonical; `cmd/skills.go` is a thin wrapper. The embedded markdown is the only copy of the guidance — no drift.
- **Layout is extensible:** dropping a `data/skills/<name>.md` auto-lists a new skill. Specialized skills (e.g. a credential-management/setup skill) and an MCP server are intentionally **out of scope** for this MVP.

## Testing

- New `internal/skills` tests (every listed skill is retrievable, `--full` is a superset, frontmatter stripped, unknown-name errors, stub sanity) and `cmd` tests (install idempotency / refuse-without-`--force` / `--force` overwrite; rune-safe `truncate`).
- Verified locally: full `mise run test` (incl. integration), `go vet`, `golangci-lint` (whole repo), `gofmt`, markdownlint on the new doc, and an end-to-end run of every subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)